### PR TITLE
Add deployment to TestPyPI with updated information.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
     name: deploy
     needs: test
     permissions:
+      contents: read
       id-token: write
     environment: release
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,23 +1,36 @@
 # constraint_handler
 
-The constraint handler is a clingo library that supports solving discrete combinatorial decision or optimization problems where constraints and variables are defined through expressions.
+The constraint handler is a clingo library that supports solving discrete
+combinatorial decision or optimization problems where constraints and variables
+are defined through expressions.
 
 ## Installation
-This project requires Python `3.12+` and can be installed either from TestPyPI or directly from source.
+
+This project requires Python `3.12+` and can be installed either from TestPyPI
+or directly from source.
+
 ### From TestPyPI
-This is the easiest way to get started. Run the following command in your terminal:
+
+This is the easiest way to get started. Run the following command in your
+terminal:
+
 ```bash
 pip install -i https://test.pypi.org/simple/ constraint-handler
 ```
+
 ### From Source (for Developers)
-To install the project for development, clone the repository and install it in editable mode.
+
+To install the project for development, clone the repository and install it in
+editable mode.
 
 ```bash
 git clone https://github.com/potassco/constraint-handler
 cd constraint-handler
 pip install -e .
 ```
+
 ## Documentation
+
 To generate and open the documentation, run
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 # constraint_handler
 
-Handle acyclic constraints over variables with large/infinite domains.
+The constraint handler is a clingo library that supports solving discrete combinatorial decision or optimization problems where constraints and variables are defined through expressions.
 
 ## Installation
-
-To install the project, run
+This project requires Python `3.12+` and can be installed either from TestPyPI or directly from source.
+### From TestPyPI
+This is the easiest way to get started. Run the following command in your terminal:
+```bash
+pip install -i https://test.pypi.org/simple/ constraint-handler
+```
+### From Source (for Developers)
+To install the project for development, clone the repository and install it in editable mode.
 
 ```bash
-pip install .
+git clone https://github.com/potassco/constraint-handler
+cd constraint-handler
+pip install -e .
 ```
-
+## Documentation
 To generate and open the documentation, run
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "constraint_handler"
 authors = [{ name = "Abdallah Saffidine", email = "abdallah.saffidine@potassco.com" }]
-description = "A template project."
+description = "Expression-based Constraint Handler for Answer Set Programming"
 requires-python = ">=3.12"
 license = { file = "LICENSE" }
 dynamic = ["version"]


### PR DESCRIPTION
This adds the ability to deploy this project to TestPyPI using the already existing GitHub action. The action was only slightly altered to grant read access due to this being a private repository.

Additionally, the project description and README.md are updated to better reflect this new way of installing the project.