### PR TITLE
change clingo to be a lower bound instead of an exact match

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 dependencies = [
     "clorm",
-    "clingo==5.7.1",
+    "clingo>=5.7.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR sets the `clingo` version as a lower bound instead of matching it exactly. This should prevent version conflicts with other projects that use a higher version of clingo.