### PR TITLE
add max operator to float

### DIFF
--- a/src/constraint_handler/data/float.lp
+++ b/src/constraint_handler/data/float.lp
@@ -1,6 +1,6 @@
 intToFloatOperator(sqrt;cos;sin;tan;acos;asin;atan).
 floatUnOperator(abs;sqrt;cos;sin;tan;acos;asin;atan;minus;floor).
-floatBinOperator(add;sub;mult;div;fdiv;pow;leq;lt;geq;gt).
+floatBinOperator(add;sub;mult;div;fdiv;pow;leq;lt;geq;gt;max).
 
 stageCompute(OP,ARGS,L) :- compute(OP,ARGS), intToFloatOperator(OP), ARGS = (val(int,V),()), L=(V,()).
 stageCompute(OP,ARGS,L) :- compute(OP,ARGS), floatUnOperator(OP), ARGS=(val(float,V),()), L=(V,()).


### PR DESCRIPTION
While trying to get TSPTW to work with floats in the benchmarks, I learned that `max` was not implemented for floats.

Adding the operator to the list worked in my smaller test instances.