### PR TITLE
Ks/propagator improvements

### DIFF
--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -37,6 +37,8 @@ class VariableValue:
         self.assigned: bool | None = None
         self.decision_level: int = sys.maxsize
 
+        self.errors: list[Exception] = []
+
     def evaluate(self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]) -> bool:
         """
         Evaluate the expression and return True if the value has changed.
@@ -66,11 +68,14 @@ class VariableValue:
                 assert self.value == ValueStatus.NOT_SET
                 return False
 
-        self.value, errors = evaluator.evaluate_expr(self.expr, env, evaluations)  # TODO: do something with errors?
+        self.value, self.errors = evaluator.evaluate_expr(self.expr, env, evaluations)
         myprint(f"{self.expr} evaluated to {self.value}")
 
-        self.decision_level = ctl.assignment.decision_level
+        self.decision_level = min(self.decision_level, ctl.assignment.decision_level)
         return True
+
+    def get_errors(self) -> list[Exception]:
+        return self.errors
 
     def vars(self) -> set[clingo.Symbol]:
         return evaluator.collectVars(self.expr)
@@ -79,16 +84,8 @@ class VariableValue:
         if self.decision_level >= dl:
             self.value = ValueStatus.NOT_SET
             self.decision_level = sys.maxsize
-            # TODO: it is possible that it is still assigned!
-            # Maybe add a second property self.assigned_decision_level?
-            # that one would be only to know when the variable was assigned
-            # but not when it got a value!
-            # then we could reset this only if self.assigned_decision_level >= dl?
-            # Maybe important for the self.literals call of Variables and so on
-            # since they check for this property
-            # Maybe we should just extend those to check for the value only,
-            # and not the assignment of the literal?
             self.assigned = None
+            self.errors = []
 
     def __eq__(self, other):
         if not isinstance(other, VariableValue):
@@ -113,19 +110,24 @@ class EvaluateVariable:
         self.value: Any = ValueStatus.NOT_SET
         self.literal: int = literal
 
+        self.errors: list[Exception] = []
+
     def evaluate(self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]) -> bool:
         """Evaluate the expression and return True if the value has changed."""
         if not ctl.assignment.is_true(self.literal):
             return False
         myprint(f"Evaluating {self.op}({self.args})")
-        value, errors = evaluator.evaluate_expr(
+        value, self.errors = evaluator.evaluate_expr(
             evaluator.Operation(self.op, self.args), env, evaluations
-        )  # TODO: do something with errors?
+        )
         self.value = value
         return True
 
     def get_value(self) -> Any:
         return self.value
+
+    def get_errors(self) -> list[Exception]:
+        return self.errors
 
     def __eq__(self, other):
         if not isinstance(other, EvaluateVariable):
@@ -192,6 +194,9 @@ class EnsureVariable:
 
     def vars(self) -> set[clingo.Symbol]:
         return self.expression.vars()
+    
+    def get_errors(self) -> list[Exception]:
+        return self.expression.get_errors()
 
     @property
     def literals(self) -> set[int]:
@@ -232,6 +237,12 @@ class Variable:
 
     def get_value(self) -> Any:
         return self.value
+    
+    def get_errors(self) -> list[Exception]:
+        errors: list[Exception] = []
+        for var_value in self.expressions:
+            errors.extend(var_value.get_errors())
+        return errors
 
     def has_unassigned(self) -> bool:
         return any(var_value.value == ValueStatus.NOT_SET for var_value in self.expressions)
@@ -339,6 +350,12 @@ class SetVariableValue:
     def add_value(self, arg: evaluator.Expr, lit: int) -> None:
         self.values.add(VariableValue(arg, lit))
 
+    def get_errors(self) -> list[Exception]:
+        errors: list[Exception] = []
+        for var_value in self.values:
+            errors.extend(var_value.get_errors())
+        return errors
+
     @property
     def literals(self) -> set[int]:
         lits = set()
@@ -422,6 +439,9 @@ class SetVariable:
 
     def add_value(self, arg: evaluator.Expr, lit: int) -> None:
         self.expressions.add_value(arg, lit)
+
+    def get_errors(self) -> list[Exception]:
+        return self.expressions.get_errors()
 
     @property
     def literals(self) -> set[int]:
@@ -524,6 +544,13 @@ class DictVariable:
     def has_domain(self) -> bool:
         return len(self.expressions) > 0
 
+    def get_errors(self) -> list[Exception]:
+        errors: list[Exception] = []
+        for key, value in self.expressions.items():
+            errors.extend(key.get_errors())
+            errors.extend(value.get_errors())
+        return errors
+
     @property
     def literals(self) -> set[int]:
         lits = set()
@@ -563,7 +590,6 @@ class DictVariable:
         return any(value.has_unassigned() for value in self.expressions.values())
 
     def vars(self) -> set[clingo.Symbol]:
-        # TODO: check if keys can also have variables
         vars = set()
         for value in self.expressions.values():
             vars.update(value.vars())
@@ -661,6 +687,12 @@ class OptimizationSum:
 
         return sum(value for var, value in vals)
 
+    def get_errors(self) -> list[Exception]:
+        errors: list[Exception] = []
+        for _, expr in self.expressions:
+            errors.extend(expr.get_errors())
+        return errors
+
     def evaluate(self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]) -> bool:
         """Evaluate the expression and return True if the value has changed."""
         changed = False
@@ -725,6 +757,8 @@ class Execution:
 
         self.parents: list[VariableType] = []
 
+        self.errors: list[Exception] = []
+
     def has_domain(self) -> bool:
         return True  # executions always have a domain
 
@@ -783,7 +817,7 @@ class Execution:
             evals[var] = evaluations[c_var]
 
         try:
-            evaluator.evaluate_stmt(self.stmt, env, evals)
+            self.errors = evaluator.evaluate_stmt(self.stmt, env, evals)
         except evaluator.FailIntegrityExn as e:
             self.decision_level = ctl.assignment.decision_level
             return EvaluationResult.CONFLICT
@@ -800,6 +834,9 @@ class Execution:
     def get_value(self) -> ValueStatus | list[tuple[clingo.Symbol, Any]]:
         return self.values
 
+    def get_errors(self) -> list[Exception]:
+        return self.errors
+
     def add_run_literal(self, lit: int):
         self.literal = lit
 
@@ -809,7 +846,7 @@ class Execution:
     def reset(self, dl: int):
         if self.decision_level >= dl:
             self.decision_level = sys.maxsize
-
+            self.errors = []
             self.values = ValueStatus.NOT_SET
 
 

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -587,8 +587,7 @@ class DictVariable:
                 # then we treat it as not present in the dict
                 # TODO: check if this is the desired behavior
                 continue
-            if len(val) == 1:
-                val = next(iter(val))
+            
             result[key_val] = val
         return result
 
@@ -629,7 +628,7 @@ class DictVariable:
             changed |= key.evaluate(evaluations, ctl, env)
             changed |= value.evaluate(evaluations, ctl, env)
 
-        if changed:
+        if changed or not self.has_unassigned():
             self.value = self.discern_value()
             if self.value != ValueStatus.NOT_SET:
                 # only update decision level if we have a value

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -145,7 +145,6 @@ class VariableValue:
 
 
 class EvaluateVariable:
-
     def __init__(self, op: evaluator.Operator, args: list[evaluator.Expr], literal: int = -1):
         self.op: evaluator.Operator = op
         self.args: list[evaluator.Expr] = args
@@ -178,16 +177,15 @@ class EvaluateVariable:
 
     def __hash__(self) -> int:
         return hash((str(self.op), str(self.args), self.literal))
-    
+
     def __str__(self) -> str:
         return f"EvaluateVariable({self.op}, {self.args})"
-    
+
     def __repr__(self) -> str:
         return self.__str__()
 
 
 class EnsureVariable:
-
     __var = clingo.Function("ensure")
 
     def __init__(self, name: str, expr: evaluator.Expr, literal: int):
@@ -477,7 +475,7 @@ class SetVariableValue:
 
     def __str__(self) -> str:
         return f"SetVariableValue({self.values})"
-    
+
     def __repr__(self) -> str:
         return self.__str__()
 
@@ -751,9 +749,9 @@ class DictVariable:
     def __repr__(self) -> str:
         return self.__str__()
 
+
 class OptimizationSum:
     def __init__(self) -> None:
-
         self.expressions: list[tuple[clingo.Symbol, VariableValue]] = []
         self.value: Any = ValueStatus.NOT_SET
 
@@ -832,7 +830,6 @@ class OptimizationSum:
 
 
 class Execution:
-
     def __init__(
         self,
         name: str,
@@ -976,7 +973,7 @@ class Execution:
 
     def __hash__(self) -> int:
         return hash((self.func_name, self.stmt, tuple(self.in_vars), tuple(self.out_vars)))
-    
+
     def __repr__(self) -> str:
         return f"Execution({self.name}, {self.func_name}, {self.stmt})"
 

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from abc import abstractmethod
 from typing import Any, Iterable, Protocol
 
 import clingo
@@ -23,48 +24,44 @@ def myprint(*args, **kwargs):
 
 class VariableType(Protocol):
     @property
-    def var(self) -> clingo.Symbol:
-        ...
+    @abstractmethod
+    def var(self) -> clingo.Symbol: ...
     @property
-    def decision_level(self) -> int:
-        ...
+    @abstractmethod
+    def decision_level(self) -> int: ...
     @property
-    def parents(self) -> list[VariableType]:
-        ...
+    @abstractmethod
+    def parents(self) -> list[VariableType]: ...
 
-    # var: clingo.Symbol
-    # decision_level: int
-    # parents: list[VariableType]
+    @property
+    @abstractmethod
+    def literals(self) -> set[int]: ...
 
-    def has_domain(self) -> bool:
-        raise NotImplementedError
+    @abstractmethod
+    def has_domain(self) -> bool: ...
 
-    def has_unassigned(self) -> bool:
-        raise NotImplementedError
+    @abstractmethod
+    def has_unassigned(self) -> bool: ...
 
-    def get_value(self) -> Any:
-        raise NotImplementedError
+    @abstractmethod
+    def get_value(self) -> Any: ...
 
-    def reset(self, dl: int) -> None:
-        raise NotImplementedError
+    @abstractmethod
+    def reset(self, dl: int) -> None: ...
 
-    def get_errors(self) -> list[Exception]:
-        raise NotImplementedError
+    @abstractmethod
+    def get_errors(self) -> list[Exception]: ...
 
-    def vars(self) -> set[clingo.Symbol]:
-        raise NotImplementedError
+    @abstractmethod
+    def vars(self) -> set[clingo.Symbol]: ...
 
+    @abstractmethod
     def evaluate(
         self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
-    ) -> EvaluationResult:
-        raise NotImplementedError
+    ) -> EvaluationResult: ...
 
-    @property
-    def literals(self) -> set[int]:
-        raise NotImplementedError
-
-    def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
-        raise NotImplementedError
+    @abstractmethod
+    def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None: ...
 
 
 class VariableValue:
@@ -107,7 +104,7 @@ class VariableValue:
             return True
 
         for var in self.vars():
-            if var not in evaluations: # and var not in evaluations[FALSE_ASSIGNMENTS]:
+            if var not in evaluations:  # and var not in evaluations[FALSE_ASSIGNMENTS]:
                 # can't evaluate yet
                 # value should not be set yet
                 assert self.value == ValueStatus.NOT_SET
@@ -267,7 +264,6 @@ class EnsureVariable:
 
     def __repr__(self) -> str:
         return f"EnsureVariable(name={self.name}, expression={self.expression})"
-    
 
 
 class Variable:
@@ -874,7 +870,7 @@ class Execution:
 
     def convert_var(self, var: clingo.Symbol | str, input=True) -> clingo.Symbol:
         exec_name: str = EXECUTION_INPUT if input else EXECUTION_OUTPUT
-        
+
         if isinstance(var, clingo.Symbol):
             var_func = var
         else:
@@ -904,7 +900,7 @@ class Execution:
             return EvaluationResult.CHANGED
 
         for var in self.converted_in_vars:
-            if var not in evaluations: # and var not in evaluations[FALSE_ASSIGNMENTS]:
+            if var not in evaluations:  # and var not in evaluations[FALSE_ASSIGNMENTS]:
                 # can't evaluate yet
                 # value should not be set yet
                 assert self.values == ValueStatus.NOT_SET

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -129,18 +129,18 @@ class VariableValue:
             self.assigned = None
             self.errors = []
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, VariableValue):
             return False
         return self.expr == other.expr
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(str(self.expr))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"VariableValue({self.expr}, {self.value})"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"VariableValue({self.expr}, {self.value})"
 
 
@@ -171,13 +171,19 @@ class EvaluateVariable:
     def get_errors(self) -> list[Exception]:
         return self.errors
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, EvaluateVariable):
             return False
         return self.op == other.op and self.args == other.args and self.literal == other.literal
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((str(self.op), str(self.args), self.literal))
+    
+    def __str__(self) -> str:
+        return f"EvaluateVariable({self.op}, {self.args})"
+    
+    def __repr__(self) -> str:
+        return self.__str__()
 
 
 class EnsureVariable:
@@ -382,18 +388,18 @@ class Variable:
 
         d[self.var] = value  # type: ignore
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, Variable):
             assert False, "Variable can only be compared to another Variable"
         return self.var == other.var and self.expressions == other.expressions
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.var, frozenset(self.expressions)))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Variable({self.name}, {self.var}, {self.expressions})"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Variable({self.name}, {self.var}, {self.expressions})"
 
 
@@ -457,20 +463,23 @@ class SetVariableValue:
 
         return changed
 
-    def reset(self, dl: int):
+    def reset(self, dl: int) -> None:
         for arg in self.values:
             arg.reset(dl)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, SetVariableValue):
             return False
         return self.values == other.values
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(frozenset(self.values))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"SetVariableValue({self.values})"
+    
+    def __repr__(self) -> str:
+        return self.__str__()
 
 
 class SetVariable:
@@ -573,16 +582,19 @@ class SetVariable:
 
         d[self.var] = value  # type: ignore
 
-    def __eq__(self, value):
+    def __eq__(self, value) -> bool:
         if not isinstance(value, SetVariable):
             assert False, "SetVariable can only be compared to another SetVariable"
         return self.var == value.var and self.expressions == value.expressions
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.var, self.expressions))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"SetVariable({self.name}, {self.var})"
+
+    def __repr__(self) -> str:
+        return self.__str__()
 
 
 class DictVariable:
@@ -664,8 +676,9 @@ class DictVariable:
 
     def vars(self) -> set[clingo.Symbol]:
         vars = set()
-        for value in self.expressions.values():
+        for key, value in self.expressions.items():
             vars.update(value.vars())
+            vars.update(key.vars())
         return vars
 
     def evaluate(
@@ -724,17 +737,19 @@ class DictVariable:
 
         d[self.var] = value  # type: ignore
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, DictVariable):
             assert False, "DictVariable can only be compared to another DictVariable"
         return self.var == other.var and self.expressions == other.expressions
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.var, frozenset(self.expressions.items())))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"DictVariable({self.name}, {self.var})"
 
+    def __repr__(self) -> str:
+        return self.__str__()
 
 class OptimizationSum:
     def __init__(self) -> None:
@@ -811,6 +826,9 @@ class OptimizationSum:
 
     def has_unassigned(self) -> bool:
         return any(expr.value == ValueStatus.NOT_SET for var, expr in self.expressions)
+
+    def __repr__(self) -> str:
+        return f"OptimizationSum({self.expressions})"
 
 
 class Execution:
@@ -955,6 +973,12 @@ class Execution:
         else:
             for out_var, val in value:
                 d[out_var] = val
+
+    def __hash__(self) -> int:
+        return hash((self.func_name, self.stmt, tuple(self.in_vars), tuple(self.out_vars)))
+    
+    def __repr__(self) -> str:
+        return f"Execution({self.name}, {self.func_name}, {self.stmt})"
 
 
 def make_dict_from_variables(

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -927,11 +927,11 @@ class Execution:
 
         try:
             self.errors = evaluator.evaluate_stmt(self.stmt, env, evals)
-        except evaluator.FailIntegrityExn as e:
+        except evaluator.FailIntegrityExn:
             self.decision_level = ctl.assignment.decision_level
             return EvaluationResult.CONFLICT
 
-        self.values = []
+        self.values: list[tuple[clingo.Symbol, Any]] = []
         for c_out_var, out_var in zip(self.converted_out_vars, self.out_vars):
             if out_var not in evals:
                 self.values.append((c_out_var, None))

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, Sequence, TypeVar
+from typing import Any, Iterable, Protocol
 
 import clingo
 
@@ -21,7 +21,46 @@ def myprint(*args, **kwargs):
         print(*args, **kwargs)
 
 
-VariableType = TypeVar("VariableType", "Variable", "SetVariable", "DictVariable", "Execution")
+class VariableType(Protocol):
+    var: clingo.Symbol
+    decision_level: int
+    parents: list[VariableType]
+
+    def has_domain(self) -> bool:
+        raise NotImplementedError
+
+    def has_unassigned(self) -> bool:
+        raise NotImplementedError
+
+    def get_value(self) -> Any:
+        raise NotImplementedError
+
+    def reset(self, dl: int) -> None:
+        raise NotImplementedError
+
+    def get_errors(self) -> list[Exception]:
+        raise NotImplementedError
+
+    def vars(self) -> set[clingo.Symbol]:
+        raise NotImplementedError
+
+    def evaluate(
+        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
+    ) -> EvaluationResult:
+        raise NotImplementedError
+
+    @property
+    def literals(self) -> set[int]:
+        raise NotImplementedError
+
+    def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
+        value = self.get_value()
+        if value == ValueStatus.NOT_SET:
+            return
+        elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
+            d[FALSE_ASSIGNMENTS].append(self.var)  # type: ignore
+
+        d[self.var] = value  # type: ignore
 
 
 class VariableValue:
@@ -39,7 +78,9 @@ class VariableValue:
 
         self.errors: list[Exception] = []
 
-    def evaluate(self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]) -> bool:
+    def evaluate(
+        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
+    ) -> bool:
         """
         Evaluate the expression and return True if the value has changed.
         We assume that a value can only be evaluated if all its variables are assigned.
@@ -112,14 +153,14 @@ class EvaluateVariable:
 
         self.errors: list[Exception] = []
 
-    def evaluate(self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]) -> bool:
+    def evaluate(
+        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
+    ) -> bool:
         """Evaluate the expression and return True if the value has changed."""
         if not ctl.assignment.is_true(self.literal):
             return False
         myprint(f"Evaluating {self.op}({self.args})")
-        value, self.errors = evaluator.evaluate_expr(
-            evaluator.Operation(self.op, self.args), env, evaluations
-        )
+        value, self.errors = evaluator.evaluate_expr(evaluator.Operation(self.op, self.args), env, evaluations)
         self.value = value
         return True
 
@@ -138,7 +179,7 @@ class EvaluateVariable:
         return hash((str(self.op), str(self.args), self.literal))
 
 
-class EnsureVariable:
+class EnsureVariable(VariableType):
 
     __var = clingo.Function("ensure")
 
@@ -156,8 +197,11 @@ class EnsureVariable:
     def parents(self) -> list[VariableType]:
         return []
 
+    def has_domain(self) -> bool:
+        return True
+
     def evaluate(
-        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]
+        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> EvaluationResult:
         """
         Evaluate the expression and return a tuple (changed, conflict).
@@ -194,7 +238,7 @@ class EnsureVariable:
 
     def vars(self) -> set[clingo.Symbol]:
         return self.expression.vars()
-    
+
     def get_errors(self) -> list[Exception]:
         return self.expression.get_errors()
 
@@ -218,7 +262,7 @@ class EnsureVariable:
         return f"EnsureVariable(name={self.name}, expression={self.expression})"
 
 
-class Variable:
+class Variable(VariableType):
     """
     A variable with a name and a value expression.
     This is supposed to mirror the assign/3 atom(also propagator_assign/3) in the ASP encoding.
@@ -237,7 +281,7 @@ class Variable:
 
     def get_value(self) -> Any:
         return self.value
-    
+
     def get_errors(self) -> list[Exception]:
         errors: list[Exception] = []
         for var_value in self.expressions:
@@ -257,7 +301,7 @@ class Variable:
         return len(self.expressions) > 0
 
     def evaluate(
-        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]
+        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> EvaluationResult:
         """
         Evaluate the expression and return a tuple (changed, conflict).
@@ -341,7 +385,7 @@ class Variable:
 
 
 class SetVariableValue:
-    def __init__(self):
+    def __init__(self) -> None:
         self.values: set[VariableValue] = set()
 
     def has_domain(self) -> bool:
@@ -390,7 +434,9 @@ class SetVariableValue:
             vars.update(arg.vars())
         return vars
 
-    def evaluate(self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]) -> bool:
+    def evaluate(
+        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
+    ) -> bool:
         """Evaluate the expression and return True if the value has changed."""
         changed = False
         for arg in self.values:
@@ -414,7 +460,7 @@ class SetVariableValue:
         return f"SetVariableValue({self.values})"
 
 
-class SetVariable:
+class SetVariable(VariableType):
     """
     A set variable with a name and a set of value expressions.
     This is supposed to mirror the set_declare/2 and set_assign/3 atom in the ASP encoding.
@@ -426,7 +472,7 @@ class SetVariable:
         self.var: clingo.Symbol = var
         self.expressions: SetVariableValue = SetVariableValue()
 
-        self.value: ValueStatus | set[Any] = ValueStatus.NOT_SET
+        self.value: ValueStatus | frozenset[Any] = ValueStatus.NOT_SET
 
         self.literal: int = lit  # this is the literal for the set declaration
         self.assigned: bool | None = None  # Truth value of the set declaration
@@ -451,7 +497,7 @@ class SetVariable:
         lits.add(self.literal)
         return lits
 
-    def get_value(self) -> ValueStatus | set[Any]:
+    def get_value(self) -> ValueStatus | frozenset[Any]:
         """
         If there is an unassigned value, return None.
         Otherwise return the set of assigned values without the None values.
@@ -465,7 +511,7 @@ class SetVariable:
         return self.expressions.vars()
 
     def evaluate(
-        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]
+        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> EvaluationResult:
         """
         Evaluate the expression and return an EvaluationResult.
@@ -517,7 +563,7 @@ class SetVariable:
         return f"SetVariable({self.name}, {self.var})"
 
 
-class DictVariable:
+class DictVariable(VariableType):
     """
     A dict variable with a name and a set of key-value expressions.
     This is supposed to mirror the multimap_declare/2 and multimap_assign/4 atom in the ASP encoding.
@@ -587,7 +633,7 @@ class DictVariable:
                 # then we treat it as not present in the dict
                 # TODO: check if this is the desired behavior
                 continue
-            
+
             result[key_val] = val
         return result
 
@@ -601,7 +647,7 @@ class DictVariable:
         return vars
 
     def evaluate(
-        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]
+        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> EvaluationResult:
         """
         Evaluate all values in the dictionary and return (changed, conflict).
@@ -660,7 +706,7 @@ class DictVariable:
 
 
 class OptimizationSum:
-    def __init__(self):
+    def __init__(self) -> None:
 
         self.expressions: list[tuple[clingo.Symbol, VariableValue]] = []
         self.value: Any = ValueStatus.NOT_SET
@@ -700,7 +746,9 @@ class OptimizationSum:
             errors.extend(expr.get_errors())
         return errors
 
-    def evaluate(self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]) -> bool:
+    def evaluate(
+        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
+    ) -> bool:
         """Evaluate the expression and return True if the value has changed."""
         changed = False
 
@@ -734,7 +782,7 @@ class OptimizationSum:
         return any(expr.value == ValueStatus.NOT_SET for var, expr in self.expressions)
 
 
-class Execution:
+class Execution(VariableType):
 
     def __init__(
         self,
@@ -769,6 +817,9 @@ class Execution:
     def has_domain(self) -> bool:
         return True  # executions always have a domain
 
+    def has_unassigned(self) -> bool:
+        return self.values == ValueStatus.NOT_SET
+
     @property
     def var(self):
         return self.func_name
@@ -793,7 +844,7 @@ class Execution:
         return v
 
     def evaluate(
-        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]
+        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> EvaluationResult:
         """Evaluate the execution and return True if the value has changed."""
         self.assigned = ctl.assignment.value(self.literal)
@@ -856,44 +907,25 @@ class Execution:
             self.errors = []
             self.values = ValueStatus.NOT_SET
 
+    def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
+        value = self.get_value()
+
+        if value == ValueStatus.NOT_SET:
+            return
+
+        elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
+            for out_var in self.converted_out_vars:
+                d[FALSE_ASSIGNMENTS].append(out_var)  # type: ignore
+        else:
+            for out_var, val in value:
+                d[out_var] = val
+
 
 def make_dict_from_variables(
-    variables: Sequence[VariableType],
+    variables: Iterable[VariableType],
 ) -> dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]:
     result: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]] = {FALSE_ASSIGNMENTS: []}
     for var in variables:
-        if type(var) == Execution:
-            add_execution_to_dict(var, result)
-        elif type(var) in (Variable, SetVariable, DictVariable):
-            add_variable_to_dict(var, result)
+        var.add_self_to_dict(result)
 
     return result
-
-
-def add_variable_to_dict(
-    var: Variable | SetVariable | DictVariable, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]
-) -> None:
-    value = var.get_value()
-
-    if value == ValueStatus.NOT_SET:
-        return
-
-    elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
-        d[FALSE_ASSIGNMENTS].append(var.var)
-
-    else:
-        d[var.var] = value
-
-
-def add_execution_to_dict(exec: Execution, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
-    value: ValueStatus | list[tuple[clingo.Symbol, Any]] = exec.get_value()
-
-    if value == ValueStatus.NOT_SET:
-        return
-
-    elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
-        for out_var in exec.converted_out_vars:
-            d[FALSE_ASSIGNMENTS].append(out_var)
-    else:
-        for out_var, val in value:
-            d[out_var] = val

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -119,7 +119,7 @@ class VariableValue:
     def get_errors(self) -> list[Exception]:
         return self.errors
 
-    def vars(self) -> set[clingo.Symbol]:
+    def vars(self) -> frozenset[clingo.Symbol]:
         return evaluator.collectVars(self.expr)
 
     def reset(self, dl):
@@ -241,7 +241,7 @@ class EnsureVariable:
     def has_unassigned(self) -> bool:
         return self.value == ValueStatus.NOT_SET
 
-    def vars(self) -> set[clingo.Symbol]:
+    def vars(self) -> frozenset[clingo.Symbol]:
         return self.expression.vars()
 
     def get_errors(self) -> list[Exception]:

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -434,6 +434,8 @@ class SetVariable:
 
         self.parents: list[VariableType] = []
 
+        self.errors: list[Exception] = []
+
     def has_domain(self) -> bool:
         return self.expressions.has_domain()
 
@@ -441,7 +443,7 @@ class SetVariable:
         self.expressions.add_value(arg, lit)
 
     def get_errors(self) -> list[Exception]:
-        return self.expressions.get_errors()
+        return self.expressions.get_errors() + self.errors
 
     @property
     def literals(self) -> set[int]:
@@ -481,6 +483,7 @@ class SetVariable:
             # Assignment is false, so value is set to false assignment
             self.value = ValueStatus.ASSIGNMENT_IS_FALSE
             self.decision_level = ctl.assignment.decision_level
+            self.errors.append(ValueError(f"Set declaration for {self.var} is False!"))
             return EvaluationResult.CHANGED
 
         changed = self.expressions.evaluate(evaluations, ctl, env)
@@ -500,6 +503,7 @@ class SetVariable:
         if self.decision_level >= dl:
             self.decision_level = sys.maxsize
             self.value = ValueStatus.NOT_SET
+            self.errors = []
 
     def __eq__(self, value):
         if not isinstance(value, SetVariable):
@@ -533,6 +537,8 @@ class DictVariable:
 
         self.parents: list[VariableType] = []
 
+        self.errors: list[Exception] = []
+
     def add_value(self, key: evaluator.Expr, expr: evaluator.Expr, lit: int) -> None:
         # setting lit for key to 1 since it does not have its own literal
         # the literal is bound for the value!
@@ -549,7 +555,7 @@ class DictVariable:
         for key, value in self.expressions.items():
             errors.extend(key.get_errors())
             errors.extend(value.get_errors())
-        return errors
+        return errors + self.errors
 
     @property
     def literals(self) -> set[int]:
@@ -615,6 +621,7 @@ class DictVariable:
         elif ctl.assignment.is_false(self.literal):
             self.value = ValueStatus.ASSIGNMENT_IS_FALSE
             self.decision_level = ctl.assignment.decision_level
+            self.errors.append(ValueError(f"Dict declaration for {self.var} is False!"))
             return EvaluationResult.CHANGED
 
         changed = False
@@ -639,6 +646,7 @@ class DictVariable:
         if self.decision_level >= dl:
             self.decision_level = sys.maxsize
             self.value = ValueStatus.NOT_SET
+            self.errors = []
 
     def __eq__(self, other):
         if not isinstance(other, DictVariable):
@@ -696,7 +704,7 @@ class OptimizationSum:
     def evaluate(self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.Control, env: dict[Any, Any]) -> bool:
         """Evaluate the expression and return True if the value has changed."""
         changed = False
-        # print(evaluations)
+
         for var, expr in self.expressions:
             changed |= expr.evaluate(evaluations, ctl, env)
 

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -22,9 +22,19 @@ def myprint(*args, **kwargs):
 
 
 class VariableType(Protocol):
-    var: clingo.Symbol
-    decision_level: int
-    parents: list[VariableType]
+    @property
+    def var(self) -> clingo.Symbol:
+        ...
+    @property
+    def decision_level(self) -> int:
+        ...
+    @property
+    def parents(self) -> list[VariableType]:
+        ...
+
+    # var: clingo.Symbol
+    # decision_level: int
+    # parents: list[VariableType]
 
     def has_domain(self) -> bool:
         raise NotImplementedError
@@ -54,13 +64,7 @@ class VariableType(Protocol):
         raise NotImplementedError
 
     def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
-        value = self.get_value()
-        if value == ValueStatus.NOT_SET:
-            return
-        elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
-            d[FALSE_ASSIGNMENTS].append(self.var)  # type: ignore
-
-        d[self.var] = value  # type: ignore
+        raise NotImplementedError
 
 
 class VariableValue:
@@ -103,7 +107,7 @@ class VariableValue:
             return True
 
         for var in self.vars():
-            if var not in evaluations and var not in evaluations[FALSE_ASSIGNMENTS]:
+            if var not in evaluations: # and var not in evaluations[FALSE_ASSIGNMENTS]:
                 # can't evaluate yet
                 # value should not be set yet
                 assert self.value == ValueStatus.NOT_SET
@@ -179,7 +183,7 @@ class EvaluateVariable:
         return hash((str(self.op), str(self.args), self.literal))
 
 
-class EnsureVariable(VariableType):
+class EnsureVariable:
 
     __var = clingo.Function("ensure")
 
@@ -255,14 +259,18 @@ class EnsureVariable(VariableType):
         if self.decision_level >= dl:
             self.value = ValueStatus.NOT_SET
 
+    def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
+        return
+
     def __hash__(self):
         return hash((self.name, self.expression))
 
     def __repr__(self) -> str:
         return f"EnsureVariable(name={self.name}, expression={self.expression})"
+    
 
 
-class Variable(VariableType):
+class Variable:
     """
     A variable with a name and a value expression.
     This is supposed to mirror the assign/3 atom(also propagator_assign/3) in the ASP encoding.
@@ -369,6 +377,15 @@ class Variable(VariableType):
             self.decision_level = sys.maxsize
             self.value = ValueStatus.NOT_SET
 
+    def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
+        value = self.get_value()
+        if value == ValueStatus.NOT_SET:
+            return
+        elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
+            d[FALSE_ASSIGNMENTS].append(self.var)  # type: ignore
+
+        d[self.var] = value  # type: ignore
+
     def __eq__(self, other):
         if not isinstance(other, Variable):
             assert False, "Variable can only be compared to another Variable"
@@ -460,7 +477,7 @@ class SetVariableValue:
         return f"SetVariableValue({self.values})"
 
 
-class SetVariable(VariableType):
+class SetVariable:
     """
     A set variable with a name and a set of value expressions.
     This is supposed to mirror the set_declare/2 and set_assign/3 atom in the ASP encoding.
@@ -551,6 +568,15 @@ class SetVariable(VariableType):
             self.value = ValueStatus.NOT_SET
             self.errors = []
 
+    def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
+        value = self.get_value()
+        if value == ValueStatus.NOT_SET:
+            return
+        elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
+            d[FALSE_ASSIGNMENTS].append(self.var)  # type: ignore
+
+        d[self.var] = value  # type: ignore
+
     def __eq__(self, value):
         if not isinstance(value, SetVariable):
             assert False, "SetVariable can only be compared to another SetVariable"
@@ -563,7 +589,7 @@ class SetVariable(VariableType):
         return f"SetVariable({self.name}, {self.var})"
 
 
-class DictVariable(VariableType):
+class DictVariable:
     """
     A dict variable with a name and a set of key-value expressions.
     This is supposed to mirror the multimap_declare/2 and multimap_assign/4 atom in the ASP encoding.
@@ -693,6 +719,15 @@ class DictVariable(VariableType):
             self.value = ValueStatus.NOT_SET
             self.errors = []
 
+    def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
+        value = self.get_value()
+        if value == ValueStatus.NOT_SET:
+            return
+        elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
+            d[FALSE_ASSIGNMENTS].append(self.var)  # type: ignore
+
+        d[self.var] = value  # type: ignore
+
     def __eq__(self, other):
         if not isinstance(other, DictVariable):
             assert False, "DictVariable can only be compared to another DictVariable"
@@ -782,18 +817,18 @@ class OptimizationSum:
         return any(expr.value == ValueStatus.NOT_SET for var, expr in self.expressions)
 
 
-class Execution(VariableType):
+class Execution:
 
     def __init__(
         self,
         name: str,
-        func_name: str,
+        func_name: clingo.Symbol,
         stmt: evaluator.Stmt,
         in_vars: list[clingo.Symbol],
         out_vars: list[clingo.Symbol],
     ):
         self.name: str = name
-        self.func_name: str = func_name
+        self.func_name: clingo.Symbol = func_name
         self.stmt: evaluator.Stmt = stmt
         self.in_vars: list[clingo.Symbol] = in_vars
         self.converted_in_vars: list[clingo.Symbol] = self.convert_vars(in_vars, input=True)
@@ -821,7 +856,7 @@ class Execution(VariableType):
         return self.values == ValueStatus.NOT_SET
 
     @property
-    def var(self):
+    def var(self) -> clingo.Symbol:
         return self.func_name
 
     @property
@@ -839,7 +874,12 @@ class Execution(VariableType):
 
     def convert_var(self, var: clingo.Symbol | str, input=True) -> clingo.Symbol:
         exec_name: str = EXECUTION_INPUT if input else EXECUTION_OUTPUT
-        var_func = var if type(var) == clingo.Symbol else clingo.String(var)
+        
+        if isinstance(var, clingo.Symbol):
+            var_func = var
+        else:
+            var_func = clingo.String(var)
+
         v = clingo.Function(exec_name, [self.func_name, var_func])
         return v
 
@@ -864,7 +904,7 @@ class Execution(VariableType):
             return EvaluationResult.CHANGED
 
         for var in self.converted_in_vars:
-            if var not in evaluations and var not in evaluations[FALSE_ASSIGNMENTS]:
+            if var not in evaluations: # and var not in evaluations[FALSE_ASSIGNMENTS]:
                 # can't evaluate yet
                 # value should not be set yet
                 assert self.values == ValueStatus.NOT_SET
@@ -924,7 +964,7 @@ class Execution(VariableType):
 def make_dict_from_variables(
     variables: Iterable[VariableType],
 ) -> dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]:
-    result: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]] = {FALSE_ASSIGNMENTS: []}
+    result: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]] = {}
     for var in variables:
         var.add_self_to_dict(result)
 

--- a/src/constraint_handler/data/propagator.lp
+++ b/src/constraint_handler/data/propagator.lp
@@ -19,3 +19,5 @@ propagator_execution_declare(CNAME,F,STMT,IN,OUT) :-
 
 propagator_execution_run(CNAME,F) :-
     execution_run(CNAME,F), engine(CNAME,propagator).
+
+propagator_evaluate(F,E) :- evaluate(F,E), defaultEngine(propagator).

--- a/src/constraint_handler/evaluator.py
+++ b/src/constraint_handler/evaluator.py
@@ -7,6 +7,7 @@ import operator
 from collections import namedtuple
 from enum import Enum
 from typing import NamedTuple
+from collections.abc import Callable
 
 import clingo
 
@@ -41,7 +42,22 @@ SetOperator = PPEnum("SetOperator", ["makeSet", "isin", "notin", "union", "inter
 StringOperator = PPEnum("StringOperator", ["concat", "length"])
 OtherOperator = PPEnum("OtherOperator", ["minus", "max", "min", "length"])
 
-MultimapOperator = PPEnum("MultimapOperator", ["find", "isin", "multimap_make", "multimap_fold"])
+MultimapOperator = PPEnum(
+    "MultimapOperator",
+    [
+        "find",
+        "find2",
+        "isin",
+        "multimap_make",
+        "multimap_fold",
+        "multimap_fold_i",
+        "countKeys",
+        "countEntries",
+        "sumIntEntries",
+        "maxEntries",
+        "minEntries",
+    ],
+)
 
 
 # ConditionalOperator = PPEnum("ConditionalOperator", ["default", "if"])
@@ -421,9 +437,35 @@ def multimap_fold(f, m, start):
     accu = start
     for key in m:
         value = m[key]
-        accu = f(value, accu)
-        # accu = f((key, value), accu)
+        accu = set_fold(f, value, accu)
     return accu
+
+
+def multimap_fold_i(f, m, start):
+    accu = start
+    for key in m:
+        value = m[key]
+        for val in value:
+            accu = f(key, val, accu)
+    return accu
+
+
+def multimap_compare(multimap: HashableDict, op: Callable):
+    best_val = None
+    errors: list[Exception] = []
+    try:
+        for key, value in multimap.items():
+            local_best = op(value)
+
+            if best_val is None or (local_best is not None and op(local_best, best_val)):
+                best_val = local_best
+
+    except TypeError as exn:
+        errors.append(NotImplementedError(f"multimap does not support comparison of values of some types: {exn}"))
+    except Exception as exn:
+        errors.append(exn)
+
+    return best_val, errors
 
 
 def set_fold(f, s, start):
@@ -527,10 +569,18 @@ class Evaluator:
             case MultimapOperator.find:
                 assert len(args) == 2
                 return args[1][args[0]] if args[0] in args[1] else frozenset()
+            case MultimapOperator.find2:
+                # args is dict, key, value
+                # return if value in d[key]
+                assert len(args) == 3
+                return args[1] in args[0] and args[2] in args[0][args[1]]
             case MultimapOperator.multimap_fold:
                 o = lambda *aaa: self.operator(args[0], aaa)  # TODO: check
                 return multimap_fold(o, args[1], args[2])
-            case MultimapOperator.multimap_make:
+            case MultimapOperator.multimap_fold_i:
+                o = lambda *aaa: self.operator(args[0], aaa)  # TODO: check
+                return multimap_fold_i(o, args[1], args[2])
+            case MultimapOperator.multimapMake:
                 d = HashableDict()
                 for key, value in args:
                     if key not in d:
@@ -541,7 +591,29 @@ class Evaluator:
                     d[key] = frozenset(value)
                 return d
 
-                # return HashableDict({key: value for (key, value) in args})
+            case MultimapOperator.countKeys:
+                return len(args[0])
+
+            case MultimapOperator.countEntries:
+                count = 0
+                for key, value in args[0].items():
+                    count += len(value)
+                return count
+
+            case MultimapOperator.sumIntEntries:
+                total = 0
+                for key, value in args[0].items():
+                    total += sum(v for v in value if isinstance(v, int))
+                return total
+
+            case MultimapOperator.maxEntries:
+                __max, erros = multimap_compare(args[0], max)
+                self.errors.extend(erros)
+                return __max
+            case MultimapOperator.minEntries:
+                __min, erros = multimap_compare(args[0], min)
+                self.errors.extend(erros)
+                return __min
             case _:
                 self.errors.append(NotImplementedError(f"multimap_operator {o}"))
                 return None
@@ -661,7 +733,9 @@ class Evaluator:
                 return self.python_operator(fn, args)
             case Lambda(vars, expr):
                 if len(vars) != len(args):
-                    self.errors.append(ValueError(f"evaluate_operator inconsistent parameters and argument lengths for {o}"))
+                    self.errors.append(
+                        ValueError(f"evaluate_operator inconsistent parameters and argument lengths for {o}")
+                    )
                     return None
                 locals = dict(self.locals)
                 for v, e in zip(vars, args):

--- a/src/constraint_handler/evaluator.py
+++ b/src/constraint_handler/evaluator.py
@@ -5,9 +5,9 @@ import importlib
 import math
 import operator
 from collections import namedtuple
+from collections.abc import Callable
 from enum import Enum
 from typing import NamedTuple
-from collections.abc import Callable
 
 import clingo
 

--- a/src/constraint_handler/evaluator.py
+++ b/src/constraint_handler/evaluator.py
@@ -395,6 +395,8 @@ def get_baseType(v):
         return BaseType.int
     elif isinstance(v, frozenset):
         return BaseType.set
+    elif isinstance(v, HashableDict):
+        return BaseType.multimap
     elif isinstance(v, clingo.Symbol):
         return BaseType.symbol
     else:

--- a/src/constraint_handler/evaluator.py
+++ b/src/constraint_handler/evaluator.py
@@ -457,8 +457,10 @@ def multimap_compare(multimap: HashableDict, op: Callable):
         for key, value in multimap.items():
             local_best = op(value)
 
-            if best_val is None or (local_best is not None and op(local_best, best_val)):
+            if best_val is None:
                 best_val = local_best
+            elif local_best is not None:
+                best_val = op(best_val, local_best)
 
     except TypeError as exn:
         errors.append(NotImplementedError(f"multimap does not support comparison of values of some types: {exn}"))

--- a/src/constraint_handler/evaluator.py
+++ b/src/constraint_handler/evaluator.py
@@ -588,7 +588,7 @@ class Evaluator:
             case MultimapOperator.multimap_fold_i:
                 o = lambda *aaa: self.operator(args[0], aaa)  # TODO: check
                 return multimap_fold_i(o, args[1], args[2])
-            case MultimapOperator.multimapMake:
+            case MultimapOperator.multimap_make:
                 d = HashableDict()
                 for key, value in args:
                     if key not in d:

--- a/src/constraint_handler/evaluator.py
+++ b/src/constraint_handler/evaluator.py
@@ -363,7 +363,11 @@ class Propagator_execution_run(Execution_run):
     pass
 
 
-def collectVars(expr) -> set[clingo.Symbol]:
+class Propagator_evaluate(Evaluate):
+    pass
+
+
+def collectVars(expr) -> frozenset[clingo.Symbol]:
     match expr:
         case Operation(eo, eargs):
             ov = collectVars(eo) if not isinstance(eo, Operator) else frozenset()

--- a/src/constraint_handler/evaluator.py
+++ b/src/constraint_handler/evaluator.py
@@ -661,7 +661,7 @@ class Evaluator:
                 return self.python_operator(fn, args)
             case Lambda(vars, expr):
                 if len(vars) != len(args):
-                    self.errors.append(f"evaluate_operator inconsistent parameters and argument lengths for {o}")
+                    self.errors.append(ValueError(f"evaluate_operator inconsistent parameters and argument lengths for {o}"))
                     return None
                 locals = dict(self.locals)
                 for v, e in zip(vars, args):

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -538,6 +538,12 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             myprint(f"Unknown model type {type(final_value)} for variable {var} in on_model!")
 
     def handle_on_model_set(self, var: clingo.Symbol, final_value: set | frozenset, model: clingo.Model):
+        pyAtom = evaluator.Value(var, evaluator.get_baseType(final_value), clingo.Function("ref", [clingo.Function("variable", [var])]))
+        clAtom = myClorm.pytocl(pyAtom)
+        myprint(f"= {clAtom}")
+        if not model.contains(clAtom):
+            model.extend([clAtom])
+
         for value in final_value:
 
             if value is ValueStatus.NOT_SET:
@@ -551,6 +557,11 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 model.extend([clAtom])
 
     def handle_on_model_dict(self, var: clingo.Symbol, final_value: dict, model: clingo.Model):
+        # TODO: If we want to use the ref system for the output here(for sets, etc) then
+        # we have to loop over the expressions in the dict, not just the final values
+        # otherwise, we don't know what the ref is for each key and value
+        # alternatively, we have a separate part of the dict that tells you which refs are for which key/value
+        
         for key, value in final_value.items():
 
             if value is ValueStatus.NOT_SET:

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -278,9 +278,11 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         for (name, symbol_var, expr), __literal in var_defines.items():
             if symbol_var in self.symbol2var:
-                self.errors.append(SyntaxError(f"Variable {name} declared and defined! variable_define will do nothing!"))
+                self.errors.append(
+                    SyntaxError(f"Variable {name} declared and defined! variable_define will do nothing!")
+                )
                 continue
-            variable: Variable = Variable(name, symbol_var)
+            variable = Variable(name, symbol_var)
             self.symbol2var[symbol_var] = variable
             variable.add_value(expr, __literal)
             ctl.add_watch(__literal)
@@ -386,7 +388,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         for (name, symbol_var), literal in declares.items():
             variable = SetVariable(name, symbol_var, literal)
             if literal != 1:
-                self.errors.append(SyntaxError(f"Set variable {name} declaration is not a fact! It has literal {literal}."))
+                self.errors.append(
+                    SyntaxError(f"Set variable {name} declaration is not a fact! It has literal {literal}.")
+                )
 
             self.symbol2var[symbol_var] = variable
             if literal not in self.literal2var:
@@ -417,7 +421,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             variable = DictVariable(name, symbol_var, literal)
 
             if literal != 1:
-                self.errors.append(SyntaxError(f"Dict variable {symbol_var} declaration is not a fact! It has literal {literal}."))
+                self.errors.append(
+                    SyntaxError(f"Dict variable {symbol_var} declaration is not a fact! It has literal {literal}.")
+                )
 
             self.symbol2var[symbol_var] = variable
             if literal not in self.literal2var:
@@ -538,7 +544,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             myprint(f"Unknown model type {type(final_value)} for variable {var} in on_model!")
 
     def handle_on_model_set(self, var: clingo.Symbol, final_value: set | frozenset, model: clingo.Model):
-        pyAtom = evaluator.Value(var, evaluator.get_baseType(final_value), clingo.Function("ref", [clingo.Function("variable", [var])]))
+        pyAtom = evaluator.Value(
+            var, evaluator.get_baseType(final_value), clingo.Function("ref", [clingo.Function("variable", [var])])
+        )
         clAtom = myClorm.pytocl(pyAtom)
         myprint(f"= {clAtom}")
         if not model.contains(clAtom):
@@ -561,7 +569,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         # we have to loop over the expressions in the dict, not just the final values
         # otherwise, we don't know what the ref is for each key and value
         # alternatively, we have a separate part of the dict that tells you which refs are for which key/value
-        
+
         for key, value in final_value.items():
 
             if value is ValueStatus.NOT_SET:
@@ -590,6 +598,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def handle_on_model_warning(self, errors: list[Exception], model: clingo.Model):
         for error in errors:
-            atom = evaluator.Warning(clingo.Function("", [clingo.Function(type(error).__name__), clingo.String(str(error))]))
+            atom = evaluator.Warning(
+                clingo.Function("", [clingo.Function(type(error).__name__), clingo.String(str(error))])
+            )
             if not model.contains(myClorm.pytocl(atom)):
                 model.extend([myClorm.pytocl(atom)])

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -158,7 +158,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         if self.optimization_sum.value != ValueStatus.NOT_SET:
             if self.optimization_sum.value <= self.best_value and not self.optimization_sum.has_unassigned():
-                ng = set()
+                ng: set[int] = set()
                 for symbol_var in self.optimization_sum.vars():
                     var = self.symbol2var[symbol_var]
                     ng = ng.union(self.get_reasons(var))
@@ -282,23 +282,23 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                     SyntaxError(f"Variable {name} declared and defined! variable_define will do nothing!")
                 )
                 continue
-            variable = Variable(name, symbol_var)
-            self.symbol2var[symbol_var] = variable
-            variable.add_value(expr, __literal)
+            define_variable = Variable(name, symbol_var)
+            self.symbol2var[symbol_var] = define_variable
+            define_variable.add_value(expr, __literal)
             ctl.add_watch(__literal)
             ctl.add_watch(-__literal)
 
         for (symbol_var, domain_expr), __literal in var_domains.items():
-            variable: Variable = self.symbol2var[symbol_var]
+            domain_variable: Variable = self.symbol2var[symbol_var]
             literal = ctl.add_literal(freeze=True)
-            variable.add_value(domain_expr, literal)
+            domain_variable.add_value(domain_expr, literal)
             ctl.add_watch(literal)
             ctl.add_watch(-literal)
 
         for (optional,), __literal in var_optionals.items():
-            variable: Variable = self.symbol2var[optional]
+            optional_variable: Variable = self.symbol2var[optional]
             literal = ctl.add_literal(freeze=True)
-            variable.add_value(evaluator.Val(evaluator.BaseType["none"], None), literal)
+            optional_variable.add_value(evaluator.Val(evaluator.BaseType["none"], None), literal)
             ctl.add_watch(literal)
             ctl.add_watch(-literal)
 
@@ -315,10 +315,11 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         assigns = myClorm.findInPropagateInit(ctl, evaluator.Propagator_assign)
         for (name, symbol_var, expr), literal in assigns.items():
+            variable: Variable
             if symbol_var in self.symbol2var:
-                variable: Variable = self.symbol2var[symbol_var]
+                variable = self.symbol2var[symbol_var]
             else:
-                variable: Variable = Variable(name, symbol_var)
+                variable = Variable(name, symbol_var)
                 self.symbol2var[symbol_var] = variable
 
             variable.add_value(expr, literal)
@@ -513,9 +514,11 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             else:
                 self.handle_on_model_value(var.var, final_value, model)
 
-        for var in self.evaluatevars:
-            self.handle_on_model_warning(var.get_errors(), model)
-            pyAtom = Evaluated(var.op, var.args, evaluator.get_baseType(var.get_value()), var.get_value())
+        for eval_var in self.evaluatevars:
+            self.handle_on_model_warning(eval_var.get_errors(), model)
+            pyAtom = Evaluated(
+                eval_var.op, eval_var.args, evaluator.get_baseType(eval_var.get_value()), eval_var.get_value()
+            )
             myprint(f"adding evaluate atom {pyAtom}", end=" ")
             clAtom = myClorm.pytocl(pyAtom)
             myprint(f"= {clAtom}")
@@ -557,12 +560,12 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             if value is ValueStatus.NOT_SET:
                 assert False, f"Set variable {var} has no value set in on_model!"
 
-            pyAtom = evaluator.Set_value(var, evaluator.get_baseType(value), value)
+            set_pyAtom = evaluator.Set_value(var, evaluator.get_baseType(value), value)
             # myprint(f"adding set atom {pyAtom}", end=" ")
-            clAtom = myClorm.pytocl(pyAtom)
-            myprint(f"= {clAtom}")
-            if not model.contains(clAtom):
-                model.extend([clAtom])
+            set_clAtom = myClorm.pytocl(set_pyAtom)
+            myprint(f"= {set_clAtom}")
+            if not model.contains(set_clAtom):
+                model.extend([set_clAtom])
 
     def handle_on_model_dict(self, var: clingo.Symbol, final_value: dict, model: clingo.Model):
         # TODO: If we want to use the ref system for the output here(for sets, etc) then

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -353,6 +353,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         for (op, args), literal in myClorm.findInPropagateInit(ctl, evaluator.Evaluate).items():
             var = EvaluateVariable(op, args, literal)
+            if literal != 1:
+                self.errors.append(SyntaxError(f"Evaluate atom {op} with args {args} is not a fact!"))
             self.evaluatevars.append(var)
 
     def get_solver_identifier(self, ctl: clingo.PropagateInit):

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, NamedTuple, Sequence
+from typing import Any, Dict, NamedTuple, Sequence, cast
 
 import clingo
 
@@ -41,7 +41,6 @@ class Evaluated(NamedTuple):
 
 
 class ConstraintHandlerPropagator(clingo.Propagator):
-
     def __init__(self, check_only: bool = False):
         self.symbol2var: Dict[clingo.Symbol, VariableType] = {}
         self.literal2var: Dict[int, list[VariableType]] = {}
@@ -58,27 +57,27 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         self.errors: list[Exception] = []
 
-    def init(self, ctl: clingo.PropagateInit):
+    def init(self, init: clingo.PropagateInit) -> None:
         if self.check_only:
             self.propagate = lambda ctl, changes: None
 
-        self.get_solver_identifier(ctl)
+        self.get_solver_identifier(init)
 
-        self.get_variables(ctl)
-        self.get_assign(ctl)
-        self.get_ensure(ctl)
-        self.get_set_declarations(ctl)
-        self.get_multimap_declarations(ctl)
-        self.get_optimization_sums(ctl)
-        self.get_execution_declarations(ctl)
+        self.get_variables(init)
+        self.get_assign(init)
+        self.get_ensure(init)
+        self.get_set_declarations(init)
+        self.get_multimap_declarations(init)
+        self.get_optimization_sums(init)
+        self.get_execution_declarations(init)
         self.set_parents()
 
-        self.get_evaluate(ctl)
+        self.get_evaluate(init)
 
         myprint("INIT DONE")
         myprint("#" * 50)
 
-    def check(self, ctl: clingo.PropagateControl):
+    def check(self, control: clingo.PropagateControl) -> None:
         """
         This method is called to check the constraints in the propagator.
         It evaluates all variables in case there were changes from the last propagation call.
@@ -88,7 +87,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         """
         myprint("CHECKING")
 
-        backtrack = self.evaluated_solver_assignment(ctl, set(self.symbol2var.values()))
+        backtrack = self.evaluated_solver_assignment(control, set(self.symbol2var.values()))
 
         if backtrack:
             myprint(f"backtracking {backtrack} due to conflicts in evaluation of variables")
@@ -97,13 +96,13 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         myprint(f"Evaluated assignments: {make_dict_from_variables(self.symbol2var.values())}")
 
         # If not backtracking, check optimization sums
-        backtrack = self.evaluate_optimization_sum(ctl)
+        backtrack = self.evaluate_optimization_sum(control)
         myprint(f"Optimization sum evaluated to {self.optimization_sum.value}")
         if backtrack:
             print(f"backtracking {backtrack} due to optimization sum being worse than best value {self.best_value}")
             return
 
-        self.check_evaluate(ctl)
+        self.check_evaluate(control)
         # if everything is good, we update the best value
         if self.using_optimization and self.optimization_sum.value > self.best_value:
             myprint(f"New best optimization value found: {self.optimization_sum.value} (old: {self.best_value})")
@@ -117,7 +116,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         for var in self.evaluatevars:
             var.evaluate(make_dict_from_variables(self.symbol2var.values()), ctl, self.environment)
 
-    def propagate(self, ctl: clingo.PropagateControl, changes: Sequence[int]) -> None:
+    def propagate(self, control: clingo.PropagateControl, changes: Sequence[int]) -> None:
         """
         This method is called to propagate the constraints in the propagator.
         It evaluates the expressions assigned to variables and checks the ensures.
@@ -125,14 +124,14 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         or the optimization value if below the best and has been completely assigned
         it adds a nogood and backtracks.
         """
-        myprint(f"PROPAGATING with changes: {changes} and decision level {ctl.assignment.decision_level}")
+        myprint(f"PROPAGATING with changes: {changes} and decision level {control.assignment.decision_level}")
         to_evaluate: set[VariableType] = set()
         for rlit in changes:
             lit = abs(rlit)
             if lit in self.literal2var:
                 to_evaluate.update(self.literal2var[lit])
 
-        backtrack = self.evaluated_solver_assignment(ctl, to_evaluate)
+        backtrack = self.evaluated_solver_assignment(control, to_evaluate)
         if backtrack:
             myprint(f"PROPAGATION DONE, backtracking {backtrack} due to conflicts in evaluation of variables")
             return
@@ -140,7 +139,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         myprint(f"Evaluated assignments: {make_dict_from_variables(self.symbol2var.values())}")
 
         # If not backtracking, check optimization sums
-        self.evaluate_optimization_sum(ctl)
+        self.evaluate_optimization_sum(control)
         myprint(f"Optimization sum evaluated to {self.optimization_sum.value}")
 
     def evaluate_optimization_sum(self, ctl: clingo.PropagateControl) -> bool:
@@ -207,9 +206,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             ng = self.get_reasons(var)
             myprint(f"Adding nogood {ng}")
             if ctl.add_nogood(ng):
-                assert (
-                    False
-                ), f"Added violated constraint but solver did not detect it for variable {var} with reasons {ng}"
+                assert False, (
+                    f"Added violated constraint but solver did not detect it for variable {var} with reasons {ng}"
+                )
             return None
 
         return eval_result == EvaluationResult.CHANGED
@@ -257,8 +256,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             if isinstance(domain, evaluator.BoolDomain):
                 literal_true = ctl.add_literal(freeze=True)
                 literal_false = ctl.add_literal(freeze=True)
-                variable.add_value(evaluator.Val(evaluator.BaseType["bool"], True), literal_true)
-                variable.add_value(evaluator.Val(evaluator.BaseType["bool"], False), literal_false)
+                variable.add_value(evaluator.Val(evaluator.BaseType.bool, True), literal_true)
+                variable.add_value(evaluator.Val(evaluator.BaseType.bool, False), literal_false)
                 ctl.add_watch(literal_true)
                 ctl.add_watch(-literal_true)
                 ctl.add_watch(literal_false)
@@ -289,16 +288,16 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             ctl.add_watch(-__literal)
 
         for (symbol_var, domain_expr), __literal in var_domains.items():
-            domain_variable: Variable = self.symbol2var[symbol_var]
+            domain_variable: Variable = cast(Variable, self.symbol2var[symbol_var])
             literal = ctl.add_literal(freeze=True)
             domain_variable.add_value(domain_expr, literal)
             ctl.add_watch(literal)
             ctl.add_watch(-literal)
 
         for (optional,), __literal in var_optionals.items():
-            optional_variable: Variable = self.symbol2var[optional]
+            optional_variable: Variable = cast(Variable, self.symbol2var[optional])
             literal = ctl.add_literal(freeze=True)
-            optional_variable.add_value(evaluator.Val(evaluator.BaseType["none"], None), literal)
+            optional_variable.add_value(evaluator.Val(evaluator.BaseType.none, None), literal)
             ctl.add_watch(literal)
             ctl.add_watch(-literal)
 
@@ -317,7 +316,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         for (name, symbol_var, expr), literal in assigns.items():
             variable: Variable
             if symbol_var in self.symbol2var:
-                variable = self.symbol2var[symbol_var]
+                variable = cast(Variable, self.symbol2var[symbol_var])
             else:
                 variable = Variable(name, symbol_var)
                 self.symbol2var[symbol_var] = variable
@@ -403,7 +402,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         assigns = myClorm.findInPropagateInit(ctl, evaluator.Propagator_set_assign)
         for (name, symbol_var, expr), literal in assigns.items():
-            setvar: SetVariable = self.symbol2var[symbol_var]
+            setvar: SetVariable = cast(SetVariable, self.symbol2var[symbol_var])
             setvar.add_value(expr, literal)
             if literal not in self.literal2var:
                 self.literal2var[literal] = []
@@ -436,7 +435,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         assigns = myClorm.findInPropagateInit(ctl, evaluator.Propagator_multimap_assign)
         for (name, symbol_var, key_expr, expr), literal in assigns.items():
-            dictvar: DictVariable = self.symbol2var[symbol_var]
+            dictvar: DictVariable = cast(DictVariable, self.symbol2var[symbol_var])
             dictvar.add_value(key_expr, expr, literal)
             if literal not in self.literal2var:
                 self.literal2var[literal] = []
@@ -460,7 +459,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         exec_runs = myClorm.findInPropagateInit(ctl, evaluator.Propagator_execution_run)
         for (name, symbol_var), literal in exec_runs.items():
-            execvar: Execution = self.symbol2var[symbol_var]
+            execvar: Execution = cast(Execution, self.symbol2var[symbol_var])
             execvar.add_run_literal(literal)
             if literal not in self.literal2var:
                 self.literal2var[literal] = []
@@ -530,7 +529,6 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             print(f"Optimization value: {self.optimization_sum.value}")
 
     def handle_on_model_value(self, var: clingo.Symbol, final_value: Any, model: clingo.Model):
-
         if final_value is ValueStatus.NOT_SET:
             assert False, f"Variable {var} has no value set in on_model!"
 
@@ -556,7 +554,6 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             model.extend([clAtom])
 
         for value in final_value:
-
             if value is ValueStatus.NOT_SET:
                 assert False, f"Set variable {var} has no value set in on_model!"
 
@@ -583,7 +580,6 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             model.extend([clAtom])
 
         for key, value in final_value.items():
-
             if value is ValueStatus.NOT_SET:
                 assert False, f"Dict variable {var} has key {key} with no value set in on_model!"
 

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -56,6 +56,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         self.check_only = check_only
 
+        self.errors: list[Exception] = []
+
     def init(self, ctl: clingo.PropagateInit):
         if self.check_only:
             self.propagate = lambda ctl, changes: None
@@ -250,6 +252,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             variable: Variable = Variable(name, symbol_var)
             self.symbol2var[symbol_var] = variable
 
+            self.errors.append(SyntaxError(f"Variable {name} declaration is not a fact!"))
+
             if isinstance(domain, evaluator.BoolDomain):
                 literal_true = ctl.add_literal(freeze=True)
                 literal_false = ctl.add_literal(freeze=True)
@@ -270,11 +274,11 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 # values will be added from facts, nothing to do here
                 pass
             else:
-                assert False, f"Unknown domain type {domain} for variable {name}"
+                self.errors.append(ValueError(f"Unknown domain type {domain} for variable {name}"))
 
         for (name, symbol_var, expr), __literal in var_defines.items():
             if symbol_var in self.symbol2var:
-                print("Warning: variable defined and declared! Definition will do nothing!")
+                self.errors.append(SyntaxError(f"Variable {name} declared and defined! variable_define will do nothing!"))
                 continue
             variable: Variable = Variable(name, symbol_var)
             self.symbol2var[symbol_var] = variable
@@ -299,7 +303,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         # check that all variables have a domain
         for var in self.symbol2var.values():
             if not var.has_domain():
-                assert False, f"Variable {var} has no domain!"
+                self.errors.append(ValueError(f"Variable {var} has no domain defined!"))
 
     def get_assign(self, ctl: clingo.PropagateInit):
         """
@@ -358,7 +362,6 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         for id, _ in myClorm.findInPropagateInit(ctl, evaluator.Main_solverIdentifier).items():
             self.environment = evaluator.get_environment(id.id)
-            # print("hello",self.environment)
 
     def get_optimization_sums(self, ctl: clingo.PropagateInit):
         """
@@ -380,6 +383,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         declares = myClorm.findInPropagateInit(ctl, evaluator.Propagator_set_declare)
         for (name, symbol_var), literal in declares.items():
             variable = SetVariable(name, symbol_var, literal)
+            self.errors.append(SyntaxError(f"Set variable {name} declaration is not a fact!"))
 
             self.symbol2var[symbol_var] = variable
             if literal not in self.literal2var:
@@ -408,6 +412,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         declares = myClorm.findInPropagateInit(ctl, evaluator.Propagator_multimap_declare)
         for (name, symbol_var), literal in declares.items():
             variable = DictVariable(name, symbol_var, literal)
+
+            self.errors.append(SyntaxError(f"Dict variable {name} declaration is not a fact!"))
+
             self.symbol2var[symbol_var] = variable
             if literal not in self.literal2var:
                 self.literal2var[literal] = []
@@ -435,6 +442,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         declares = myClorm.findInPropagateInit(ctl, evaluator.Propagator_execution_declare)
         for (name, symbol_var, stmt, in_v, out_v), literal in declares.items():
             variable = Execution(name, symbol_var, stmt, in_v, out_v)
+
+            self.errors.append(SyntaxError(f"Execution {name} declaration is not a fact!"))
+
             self.symbol2var[symbol_var] = variable
 
         exec_runs = myClorm.findInPropagateInit(ctl, evaluator.Propagator_execution_run)
@@ -470,6 +480,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 self.symbol2var[symbol_var].parents.append(var)
 
     def on_model(self, model: clingo.Model):
+        self.handle_on_model_warning(self.errors, model)
+
         for var in self.symbol2var.values():
             self.handle_on_model_warning(var.get_errors(), model)
             if isinstance(var, EnsureVariable):

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -353,7 +353,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         It reads the propagator_assign atoms and creates Variable instances.
         """
 
-        for (op, args), literal in myClorm.findInPropagateInit(ctl, evaluator.Evaluate).items():
+        for (op, args), literal in myClorm.findInPropagateInit(ctl, evaluator.Propagator_evaluate).items():
             var = EvaluateVariable(op, args, literal)
             if literal != 1:
                 self.errors.append(SyntaxError(f"Evaluate atom {op} with args {args} is not a fact!"))

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -207,7 +207,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             myprint(f"Adding nogood {ng}")
             if ctl.add_nogood(ng):
                 assert False, (
-                    f"Added violated constraint but solver did not detect it for variable {var} with reasons {ng}"
+                    f"Added violated constraint but solver did not detect it for variable {var} with reasons {ng}",
                 )
             return None
 

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -471,6 +471,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def on_model(self, model: clingo.Model):
         for var in self.symbol2var.values():
+            self.handle_on_model_warning(var.get_errors(), model)
             if isinstance(var, EnsureVariable):
                 continue
             final_value = var.get_value()
@@ -491,16 +492,16 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 self.handle_on_model_value(var.var, final_value, model)
 
         for var in self.evaluatevars:
-            # if var.value is None or var.value is VALUE_NOT_SET:
-            #     continue
+            self.handle_on_model_warning(var.get_errors(), model)
             pyAtom = Evaluated(var.op, var.args, evaluator.get_baseType(var.get_value()), var.get_value())
-            # myprint(f"adding evaluate atom {pyAtom}", end=" ")
+            myprint(f"adding evaluate atom {pyAtom}", end=" ")
             clAtom = myClorm.pytocl(pyAtom)
             myprint(f"= {clAtom}")
             if not model.contains(clAtom):
                 model.extend([clAtom])
 
         if self.using_optimization:
+            self.handle_on_model_warning(self.optimization_sum.get_errors(), model)
             print(f"Optimization value: {self.optimization_sum.value}")
 
     def handle_on_model_value(self, var: clingo.Symbol, final_value: Any, model: clingo.Model):
@@ -558,3 +559,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         if not model.contains(clAtom):
             model.extend([clAtom])
+
+    def handle_on_model_warning(self, errors: list[Exception], model: clingo.Model):
+        for error in errors:
+            atom = evaluator.Warning(clingo.Function("", [clingo.Function(type(error).__name__), clingo.String(str(error))]))
+            if not model.contains(myClorm.pytocl(atom)):
+                model.extend([myClorm.pytocl(atom)])

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -385,7 +385,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         declares = myClorm.findInPropagateInit(ctl, evaluator.Propagator_set_declare)
         for (name, symbol_var), literal in declares.items():
             variable = SetVariable(name, symbol_var, literal)
-            self.errors.append(SyntaxError(f"Set variable {name} declaration is not a fact!"))
+            if literal != 1:
+                self.errors.append(SyntaxError(f"Set variable {name} declaration is not a fact! It has literal {literal}."))
 
             self.symbol2var[symbol_var] = variable
             if literal not in self.literal2var:
@@ -415,7 +416,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         for (name, symbol_var), literal in declares.items():
             variable = DictVariable(name, symbol_var, literal)
 
-            self.errors.append(SyntaxError(f"Dict variable {name} declaration is not a fact!"))
+            if literal != 1:
+                self.errors.append(SyntaxError(f"Dict variable {symbol_var} declaration is not a fact! It has literal {literal}."))
 
             self.symbol2var[symbol_var] = variable
             if literal not in self.literal2var:
@@ -554,14 +556,15 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             if value is ValueStatus.NOT_SET:
                 assert False, f"Dict variable {var} has key {key} with no value set in on_model!"
 
-            pyAtom = evaluator.Multimap_value(
-                var, evaluator.get_baseType(key), key, evaluator.get_baseType(value), value
-            )
-            # myprint(f"adding multimap atom {pyAtom}", end=" ")
-            clAtom = myClorm.pytocl(pyAtom)
-            myprint(f"= {clAtom}")
-            if not model.contains(clAtom):
-                model.extend([clAtom])
+            for val in value:
+                pyAtom = evaluator.Multimap_value(
+                    var, evaluator.get_baseType(key), key, evaluator.get_baseType(val), val
+                )
+                # myprint(f"adding multimap atom {pyAtom}", end=" ")
+                clAtom = myClorm.pytocl(pyAtom)
+                myprint(f"= {clAtom}")
+                if not model.contains(clAtom):
+                    model.extend([clAtom])
 
     def handle_on_model_normal_type(
         self, var: clingo.Symbol, final_value: bool | int | float | str | clingo.Symbol, model: clingo.Model

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -257,8 +257,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             if isinstance(domain, evaluator.BoolDomain):
                 literal_true = ctl.add_literal(freeze=True)
                 literal_false = ctl.add_literal(freeze=True)
-                variable.add_value(evaluator.Val(bool, True), literal_true)
-                variable.add_value(evaluator.Val(bool, False), literal_false)
+                variable.add_value(evaluator.Val(evaluator.BaseType["bool"], True), literal_true)
+                variable.add_value(evaluator.Val(evaluator.BaseType["bool"], False), literal_false)
                 ctl.add_watch(literal_true)
                 ctl.add_watch(-literal_true)
                 ctl.add_watch(literal_false)
@@ -298,7 +298,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         for (optional,), __literal in var_optionals.items():
             variable: Variable = self.symbol2var[optional]
             literal = ctl.add_literal(freeze=True)
-            variable.add_value(evaluator.Val(type(None), None), literal)
+            variable.add_value(evaluator.Val(evaluator.BaseType["none"], None), literal)
             ctl.add_watch(literal)
             ctl.add_watch(-literal)
 

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -499,10 +499,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 continue
             final_value = var.get_value()
             # myprint(var.var, final_value, type(final_value))
-            if final_value is ValueStatus.NOT_SET:
-                assert False, f"Variable {var} has no value set in on_model!"
 
-            elif final_value is ValueStatus.ASSIGNMENT_IS_FALSE:
+            assert final_value is not ValueStatus.NOT_SET, f"Variable {var} has no value set in on_model!"
+
+            if final_value is ValueStatus.ASSIGNMENT_IS_FALSE:
                 continue
 
             elif isinstance(var, Execution):
@@ -573,20 +573,29 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         # otherwise, we don't know what the ref is for each key and value
         # alternatively, we have a separate part of the dict that tells you which refs are for which key/value
 
+        # TODO: Type for dict is not handled here which results in a none value being output for the type in the value atom
+        pyAtom = evaluator.Value(
+            var, evaluator.get_baseType(final_value), clingo.Function("ref", [clingo.Function("variable", [var])])
+        )
+        clAtom = myClorm.pytocl(pyAtom)
+        myprint(f"= {clAtom}")
+        if not model.contains(clAtom):
+            model.extend([clAtom])
+
         for key, value in final_value.items():
 
             if value is ValueStatus.NOT_SET:
                 assert False, f"Dict variable {var} has key {key} with no value set in on_model!"
 
             for val in value:
-                pyAtom = evaluator.Multimap_value(
+                mm_pyAtom = evaluator.Multimap_value(
                     var, evaluator.get_baseType(key), key, evaluator.get_baseType(val), val
                 )
                 # myprint(f"adding multimap atom {pyAtom}", end=" ")
-                clAtom = myClorm.pytocl(pyAtom)
-                myprint(f"= {clAtom}")
-                if not model.contains(clAtom):
-                    model.extend([clAtom])
+                mm_clAtom = myClorm.pytocl(mm_pyAtom)
+                myprint(f"= {mm_clAtom}")
+                if not model.contains(mm_clAtom):
+                    model.extend([mm_clAtom])
 
     def handle_on_model_normal_type(
         self, var: clingo.Symbol, final_value: bool | int | float | str | clingo.Symbol, model: clingo.Model

--- a/src/constraint_handler/utils/testing.py
+++ b/src/constraint_handler/utils/testing.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Union
+from typing import Callable, Optional, Sequence, Union
 
 import clingo
 import clingo.symbol
@@ -48,13 +48,12 @@ class TheoryContains(clintest.assertion.Assertion):
 
 
 class SolverWithPropagators(clintest.solver.Solver):
-
     def __init__(
         self,
         arguments: Optional[Sequence[str]] = None,
         program: Optional[str] = None,
         files: Optional[Sequence[str]] = None,
-        propagators: list[clingo.propagator.Propagator] = [],
+        propagators: list[clingo.propagator.Propagator | Callable[..., clingo.propagator.Propagator]] = [],
     ) -> None:
         self.__arguments = [] if arguments is None else arguments
         self.__program = "" if program is None else program

--- a/tests/example/multimap_basics.expected.all
+++ b/tests/example/multimap_basics.expected.all
@@ -1,3 +1,7 @@
+set_value(in5,str,"c")
+set_value(inc,int,6)
+value(isin5,bool,true)
+value(isin6,bool,false)
 evaluated(eq,(variable(m1a),(operation(makeSet,(val(int,1),())),())),bool,true)
 evaluated(eq,(variable(m1b),(operation(makeSet,(val(int,2),(val(int,3),()))),())),bool,true)
 evaluated(eq,(variable(m1c),(operation(makeSet,(())),())),bool,true)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -75,7 +75,7 @@ propagator_extra = []
     base_tests + compile_extra,
 )
 def test_engine_compile(name: str):
-    unsupported = ["optimize_bools", "optimize_floats", "optimize_ints", "multimap_basics"]
+    unsupported: list[str] = ["optimize_bools", "optimize_floats", "optimize_ints", "multimap_basics"]
 
     if name in unsupported:
         return
@@ -88,7 +88,7 @@ def test_engine_compile(name: str):
     base_tests + ground_extra,
 )
 def test_engine_ground(name: str):
-    unsupported = [
+    unsupported: list[str] = [
         "lambdas",
         "lambda_recursive",
         "multimap_basics",
@@ -111,7 +111,7 @@ def test_engine_ground(name: str):
     + list(zip(base_tests + propagator_extra, [False] * len(base_tests + propagator_extra))),
 )
 def test_engine_propagator(name, check_mode):
-    unsupported = [
+    unsupported: list[str] = [
         "lambda_recursive",
         "multimap_basics",
         "multimaps",

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -25,13 +25,13 @@ def run_test_ground(name):
     test.assert_()
 
 
-def run_test_propagator(name):
+def run_test_propagator(name: str, check_mode: bool):
     name = "tests/example/" + name
     solver = chut.SolverWithPropagators(
         ["0", "--heuristic=Domain"],
         "defaultEngine(propagator).",
         files=[name + ".lp"],
-        propagators=[prop.ConstraintHandlerPropagator],
+        propagators=[lambda: prop.ConstraintHandlerPropagator(check_mode)],
     )
     test = chut.build_expectations(name)
     solver.solve(test)
@@ -65,17 +65,29 @@ base_tests = [
     "variables",
 ]
 
+compile_extra = ["preferences"]
+ground_extra = []
+propagator_extra = []
 
-def test_engine_compile():
-    extra = ["preferences"]
+
+@pytest.mark.parametrize(
+    "name",
+    base_tests + compile_extra,
+)
+def test_engine_compile(name: str):
     unsupported = ["optimize_bools", "optimize_floats", "optimize_ints"]
-    for test in base_tests + extra:
-        if test not in unsupported:
-            run_test_compile(test)
+
+    if name in unsupported:
+        return
+
+    run_test_compile(name)
 
 
-def test_engine_ground():
-    extra = []
+@pytest.mark.parametrize(
+    "name",
+    base_tests + ground_extra,
+)
+def test_engine_ground(name: str):
     unsupported = [
         "lambdas",
         "lambda_recursive",
@@ -87,34 +99,18 @@ def test_engine_ground():
         "set_iterations",
         "set_selfref",
     ]
-    for test in base_tests + extra:
-        if test not in unsupported:
-            run_test_ground(test)
+    if name in unsupported:
+        return
 
-
-# def test_engine_propagator():
-#     extra = []
-#     unsupported = [
-#         "lambda_recursive",
-#         "multimaps",
-#         "optimize_bools",
-#         "optimize_floats",
-#         "optimize_ints",
-#         "set_iterations",
-#         "set_selfref",
-#         "lambdas",
-#         "multimap_basics",
-#     ]
-#     for test in base_tests + extra:
-#         if test not in unsupported:
-#             run_test_propagator(test)
+    run_test_ground(name)
 
 
 @pytest.mark.parametrize(
     ["name", "check_mode"],
-    list(zip(base_tests, [True] * len(base_tests))) + list(zip(base_tests, [False] * len(base_tests))),
+    list(zip(base_tests + propagator_extra, [True] * len(base_tests + propagator_extra)))
+    + list(zip(base_tests + propagator_extra, [False] * len(base_tests + propagator_extra))),
 )
-def test_propagator(name, check_mode):
+def test_engine_propagator(name, check_mode):
     unsupported = [
         "lambda_recursive",
         "multimap_basics",
@@ -130,19 +126,4 @@ def test_propagator(name, check_mode):
     if name in unsupported:
         return
 
-    name = "tests/example/" + name
-    solver = chut.SolverWithPropagators(
-        ["0", "--heuristic=Domain"],
-        "defaultEngine(propagator).",
-        files=[name + ".lp"],
-        propagators=[lambda: prop.ConstraintHandlerPropagator(check_mode)],
-    )
-    test = chut.build_expectations(name)
-    solver.solve(test)
-    test.assert_()
-
-
-if __name__ == "__main__":
-    test_engine_compile()
-    test_engine_ground()
-    test_engine_propagator()
+    run_test_propagator(name, check_mode)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -8,6 +8,7 @@ clingo.script.enable_python()
 
 import pytest
 
+
 def run_test_compile(name):
     name = "tests/example/" + name
     solver = Clingo(["0", "--heuristic=Domain"], "defaultEngine(compile).", files=[name + ".lp"])
@@ -90,6 +91,7 @@ def test_engine_ground():
         if test not in unsupported:
             run_test_ground(test)
 
+
 # def test_engine_propagator():
 #     extra = []
 #     unsupported = [
@@ -107,7 +109,11 @@ def test_engine_ground():
 #         if test not in unsupported:
 #             run_test_propagator(test)
 
-@pytest.mark.parametrize(["name", "check_mode"], list(zip(base_tests, [True]*len(base_tests))) + list(zip(base_tests, [False]*len(base_tests))))
+
+@pytest.mark.parametrize(
+    ["name", "check_mode"],
+    list(zip(base_tests, [True] * len(base_tests))) + list(zip(base_tests, [False] * len(base_tests))),
+)
 def test_propagator(name, check_mode):
     unsupported = [
         "lambda_recursive",
@@ -123,13 +129,13 @@ def test_propagator(name, check_mode):
     ]
     if name in unsupported:
         return
-    
+
     name = "tests/example/" + name
     solver = chut.SolverWithPropagators(
         ["0", "--heuristic=Domain"],
         "defaultEngine(propagator).",
         files=[name + ".lp"],
-        propagators=[lambda : prop.ConstraintHandlerPropagator(check_mode)],
+        propagators=[lambda: prop.ConstraintHandlerPropagator(check_mode)],
     )
     test = chut.build_expectations(name)
     solver.solve(test)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -75,7 +75,7 @@ propagator_extra = []
     base_tests + compile_extra,
 )
 def test_engine_compile(name: str):
-    unsupported = ["optimize_bools", "optimize_floats", "optimize_ints"]
+    unsupported = ["optimize_bools", "optimize_floats", "optimize_ints", "multimap_basics"]
 
     if name in unsupported:
         return

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -113,7 +113,6 @@ def test_engine_ground(name: str):
 def test_engine_propagator(name, check_mode):
     unsupported: list[str] = [
         "lambda_recursive",
-        "multimap_basics",
         "multimaps",
         "optimize_bools",
         "optimize_floats",

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -6,6 +6,7 @@ import constraint_handler.utils.testing as chut
 
 clingo.script.enable_python()
 
+import pytest
 
 def run_test_compile(name):
     name = "tests/example/" + name
@@ -89,9 +90,25 @@ def test_engine_ground():
         if test not in unsupported:
             run_test_ground(test)
 
+# def test_engine_propagator():
+#     extra = []
+#     unsupported = [
+#         "lambda_recursive",
+#         "multimaps",
+#         "optimize_bools",
+#         "optimize_floats",
+#         "optimize_ints",
+#         "set_iterations",
+#         "set_selfref",
+#         "lambdas",
+#         "multimap_basics",
+#     ]
+#     for test in base_tests + extra:
+#         if test not in unsupported:
+#             run_test_propagator(test)
 
-def test_engine_propagator():
-    extra = []
+@pytest.mark.parametrize(["name", "check_mode"], list(zip(base_tests, [True]*len(base_tests))) + list(zip(base_tests, [False]*len(base_tests))))
+def test_propagator(name, check_mode):
     unsupported = [
         "lambda_recursive",
         "multimap_basics",
@@ -101,10 +118,22 @@ def test_engine_propagator():
         "optimize_ints",
         "set_iterations",
         "set_selfref",
+        "lambdas",
+        "multimap_basics",
     ]
-    for test in base_tests + extra:
-        if test not in unsupported:
-            run_test_propagator(test)
+    if name in unsupported:
+        return
+    
+    name = "tests/example/" + name
+    solver = chut.SolverWithPropagators(
+        ["0", "--heuristic=Domain"],
+        "defaultEngine(propagator).",
+        files=[name + ".lp"],
+        propagators=[lambda : prop.ConstraintHandlerPropagator(check_mode)],
+    )
+    test = chut.build_expectations(name)
+    solver.solve(test)
+    test.assert_()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Multimap values are now always a set
- Add more missing multimap operator implementations: CountKeys, CountEntries, sumIntEntries, maxEntries, minEntries
- Add new multimap operators: find2, multimap_fold_i(Missing tests for those)
- Fix bugs with parents of multimaps
- Add several warnings 
- General Code improvements
- Improve output for sets and multimaps for the propagator
- evaluate/2 atoms are handled by the propagator if it is the default engine
- Tests now use pytest.mark.parametrize to give files to the testing function