### PR TITLE
Mkdocstrings python import fix

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,24 +102,12 @@ plugins:
       handlers:
         python:
           paths: [src]
-          import:
-            - https://docs.python.org/3/objects.inv
           options:
             show_symbol_type_heading: true
             show_symbol_type_toc: true
-            # show_root_toc_entry: false
-            # show_inherited_summary: true
-            show_inherited_detail: true
-            show_inherited_detail_toc: true
-            show_inherited_detail_tree: true
             show_signature_annotations: true
             signature_crossrefs: true
             show_source: false
-        asp:
-          options:
-            glossary: true
-            predicate_table: true
-            start_level: 1
 
 hooks:
   - docs/_hooks/links_hook.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ test = ["pytest", "clintest>=0.4"]
 doc = [
     "mkdocs",
     "mkdocs-material",
-    "mkdocstrings[python]",
+    "mkdocstrings[python]>=1.0.2",
     "mkdocs-literate-nav"
 ]
 dev = ["constraint_handler[test,typecheck,lint_pylint, doc]"]


### PR DESCRIPTION
This fixes the error appearing after a fresh install due to changes in the mkdocstrings[python] config api.