### PR TITLE
update python examples in fact format

### DIFF
--- a/docs/fact-format/fact-format.tex
+++ b/docs/fact-format/fact-format.tex
@@ -204,10 +204,10 @@ ensure(example_check2,operation(leq,
 \paragraph{Other examples}
 
 \begin{verbatim}
-operation(python(val(str,"maths.cos")),(val(float,float("0.1")),()))
-operation(python(val(str,"lambda x,y: x+y*y")),
-         (variable(v1),
-         (val(float,float("0.1")),())))
+variable_define(define_named, py_named_function, operation(python("math.cos"),(val(float,float("0.1")),()))).
+variable_define(define_lambda, py_lambda, operation(python("lambda x,y: x+y*y"),
+         (val(float,float("2.0")),
+         (val(float,float("0.1")),())))).
 
 ensure(c1,operation(eq,
                    (variable(v1),


### PR DESCRIPTION
I went to close issue #66, but then I re-read the title and I think I get what was meant now.

The fact format includes two python examples:
```prolog
operation(python(val(str,"maths.cos")),(val(float,float("0.1")),()))
```
and:
```prolog
operation(python(val(str,"lambda x,y: x+y*y")),
         (variable(v1),
         (val(float,float("0.1")),())))
```
However, these are outdated, since the python operator no longer takes a `val` but only a normal ASP `string` instead. Additionally, the first example uses `maths` but the intended python module is called `math`.

The second example also includes some variable `v1` that is never defined, which may or may not be confusing.

The file `example3.lp` also contains an outdated syntax. However, there I found another issue which I highlight in #105 