### PR TITLE
Internalize computed

### DIFF
--- a/docs/developer/fact-format.md
+++ b/docs/developer/fact-format.md
@@ -137,8 +137,6 @@ This page describes the EBNF grammar for the fact format used by the constraint 
 <atom> ::=
     | "assign" "(" <term> "," <term> "," <expression> ")"
     | "ensure" "(" <term> "," <expression> ")"
-    | "compute" "(" <term> "," <val-list> ")"
-    | "computed" "(" <term> "," <val-list> "," <type> "," <term> ")"
     | "evaluate" "(" <operator> "," <expression-list> ")"
     | <variable-atom>
     | <multimap-atom>

--- a/docs/fact-format/fact-format.tex
+++ b/docs/fact-format/fact-format.tex
@@ -142,8 +142,6 @@
 <atom> ::=
 ~\alt`assign' `(' <term> `,' <term> `,' <expression> `)'
 \alt `ensure' `(' <term> `,' <expression> `)'
-\alt `compute' `(' <term> `,' <val-list> `)'
-\alt `computed' `(' <term> `,' <val-list> `,' <type> `,' <term> `)'
 \alt `evaluate' `(' <operator> `,' <expression-list> `)'
 \alt <variable-atom>
 \alt <multimap-atom>

--- a/docs/reference/language_concepts.md
+++ b/docs/reference/language_concepts.md
@@ -152,8 +152,6 @@ A list of declarations used to define problems.
 | Declaration | Description |
 |-|-|
 | [ensure] | Declares a constraint that must hold in all valid solutions. |
-| [compute] | Experimental and not documented. |
-| [computed] | Experimental and not documented. |
 | [evaluate] | Experimental and not documented. |
 | **Variable** | |
 | [domain] | Defines a domain of possible values for variables. |

--- a/src/constraint_handler/data/bool.lp
+++ b/src/constraint_handler/data/bool.lp
@@ -1,18 +1,18 @@
 %%%%%%%%%%%%%%%%% eq neq
 operator_declare(OP,(T,(T,())),T) :- T = bool, OP = (eq;neq).
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=eq,  ARGS = (val(bool,V1),(val(bool,V2),())), V1 =  V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=eq,  ARGS = (val(bool,V1),(val(bool,V2),())), V1 != V2.
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=neq, ARGS = (val(bool,V1),(val(bool,V2),())), V1 != V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=neq, ARGS = (val(bool,V1),(val(bool,V2),())), V1 =  V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=eq,  ARGS = (val(bool,V1),(val(bool,V2),())), V1 =  V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=eq,  ARGS = (val(bool,V1),(val(bool,V2),())), V1 != V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=neq, ARGS = (val(bool,V1),(val(bool,V2),())), V1 != V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=neq, ARGS = (val(bool,V1),(val(bool,V2),())), V1 =  V2.
 
 %%%%%%%%%%%%%%%%% lnot, snot, wnot
 operator_declare(OP,(T,()),T) :- T = bool, OP = (lnot;snot;wnot).
-computed(NEG,ARGS,val(bool,true))  :- compute(NEG,ARGS), NEG=(lnot;snot;wnot), ARGS=(val(bool,false),()).
-computed(NEG,ARGS,val(bool,false)) :- compute(NEG,ARGS), NEG=(lnot;snot;wnot), ARGS=(val(bool,true),()).
+_computed(NEG,ARGS,val(bool,true))  :- _compute(NEG,ARGS), NEG=(lnot;snot;wnot), ARGS=(val(bool,false),()).
+_computed(NEG,ARGS,val(bool,false)) :- _compute(NEG,ARGS), NEG=(lnot;snot;wnot), ARGS=(val(bool,true),()).
 
 %% logical/classical negation
 operator_declare(OP,(T,()),T) :- T = none, OP = (lnot).
-computed(lnot,ARGS,val(none,none))  :- compute(lnot,ARGS), ARGS=(val(none,none),()).
+_computed(lnot,ARGS,val(none,none))  :- _compute(lnot,ARGS), ARGS=(val(none,none),()).
 
 %% strong negation / strict negation
 operator_declare(OP,(T1,()),T2) :- T1 = bool,T2 = none, OP = (snot;wnot).
@@ -22,12 +22,12 @@ _se_value(E,val(bool,false))  :- direct_query(E), E=operation(snot,(E1,())), con
 _se_value(E,val(bool,true))  :- direct_query(E), E=operation(wnot,(E1,())), conditional_hasNoValue(E1).
 
 %%%%%%%%%%%%%%%%% conj disj limp
-%% The compute/computed interface is given below the eValue interface
+%% The _compute/_computed interface is given below the eValue interface
 %% We use the eValue interface because it allows short-circuit evaluation
 operator_declare_variadic(OP,T,T,1) :- T = bool, OP = (conj;disj).
-%computedIdx(E,bool,true)  :- computeIdx(E,conj), E=operation(conj,L), _se_value(E1,val(bool,true)) : E1=@pythonListElements(L).
-computedIdx(E,val(bool,false)) :- computeIdx(E,conj), computeIdx(E,IDX,val(bool,false)).
-computedIdx(E,val(bool,true))  :- computeIdx(E,conj), computeIdx(E,IDX,val(bool,true)) : computeIdx(E,IDX,V).
+%_computedIdx(E,bool,true)  :- _computeIdx(E,conj), E=operation(conj,L), _se_value(E1,val(bool,true)) : E1=@pythonListElements(L).
+_computedIdx(E,val(bool,false)) :- _computeIdx(E,conj), _computeIdx(E,IDX,val(bool,false)).
+_computedIdx(E,val(bool,true))  :- _computeIdx(E,conj), _computeIdx(E,IDX,val(bool,true)) : _computeIdx(E,IDX,V).
 
 %_se_value(E,val(bool,true))  :- direct_query(E), E=operation(conj,L), _se_value(E1,val(bool,true)) : E1=@pythonListElements(L).
 %_se_value(E,val(bool,false)) :- direct_query(E), E=operation(conj,L), _se_value(E1,val(bool,false)), E1=@pythonListElements(L).
@@ -38,22 +38,22 @@ _se_value(E,val(bool,false)) :- direct_query(E), E=operation(disj,L), _se_value(
 %_se_value(E,val(bool,true))  :- direct_query(E), E=operation(limp, (E1,(E2,()))), _se_value(E1,val(bool,false)).
 %_se_value(E,val(bool,true))  :- direct_query(E), E=operation(limp, (E1,(E2,()))), _se_value(E2,val(bool,true)).
 %_se_value(E,val(bool,false)) :- direct_query(E), E=operation(limp, (E1,(E2,()))), _se_value(E1,val(bool,true)), _se_value(E2,val(bool,false)).
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=limp,  ARGS = (val(bool,false),(val(T2,V2),())).
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=limp,  ARGS = (val(T1,V1),(val(bool,true),())).
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=limp,  ARGS = (val(bool,true),(val(bool,false),())).
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=limp,  ARGS = (val(bool,false),(val(T2,V2),())).
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=limp,  ARGS = (val(T1,V1),(val(bool,true),())).
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=limp,  ARGS = (val(bool,true),(val(bool,false),())).
 
-computed(OP,ARGS,val(none,none)) :- compute(OP,ARGS), OP=limp,  ARGS = (val(bool,true),(val(none,none),())).
-computed(OP,ARGS,val(none,none)) :- compute(OP,ARGS), OP=limp,  ARGS = (val(none,none),(val(bool,false),())).
-computed(OP,ARGS,val(none,none)) :- compute(OP,ARGS), OP=limp,  ARGS = (val(none,none),(val(none,none),())).
+_computed(OP,ARGS,val(none,none)) :- _compute(OP,ARGS), OP=limp,  ARGS = (val(bool,true),(val(none,none),())).
+_computed(OP,ARGS,val(none,none)) :- _compute(OP,ARGS), OP=limp,  ARGS = (val(none,none),(val(bool,false),())).
+_computed(OP,ARGS,val(none,none)) :- _compute(OP,ARGS), OP=limp,  ARGS = (val(none,none),(val(none,none),())).
 
 %%%%%%%%%%%%%%%%% lxor leqv
 operator_declare_variadic(OP,T,T,1) :- T = bool, OP = (lxor;leqv).
-computed(lxor,ARGS,val(bool,true))  :- compute(lxor,ARGS),
+_computed(lxor,ARGS,val(bool,true))  :- _compute(lxor,ARGS),
     N = #count { I : (I,val(bool,true))=@pythonEnumerateElements(ARGS) }, N \ 2 = 1.
-computed(lxor,ARGS,val(bool,false)) :- compute(lxor,ARGS),
+_computed(lxor,ARGS,val(bool,false)) :- _compute(lxor,ARGS),
     N = #count { I : (I,val(bool,true))=@pythonEnumerateElements(ARGS) }, N \ 2 = 0.
 
-computed(leqv,ARGS,val(bool,true))  :- compute(leqv,ARGS),
+_computed(leqv,ARGS,val(bool,true))  :- _compute(leqv,ARGS),
     N = #count { I : (I,val(bool,false))=@pythonEnumerateElements(ARGS) }, N \ 2 = 0.
-computed(leqv,ARGS,val(bool,false)) :- compute(leqv,ARGS),
+_computed(leqv,ARGS,val(bool,false)) :- _compute(leqv,ARGS),
     N = #count { I : (I,val(bool,false))=@pythonEnumerateElements(ARGS) }, N \ 2 = 1.

--- a/src/constraint_handler/data/conditionals.lp
+++ b/src/constraint_handler/data/conditionals.lp
@@ -5,10 +5,10 @@ conditional_hasNoValue(E) :- direct_query(E), _se_value(E,val(none,none)).
 
 %%%%%%%%%%%%%%%%% eq neq
 operator_declare(OP,(T1,(T2,())),bool) :- _type(T1), _type(T2), OP = (eq;neq).
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=eq,  ARGS = (val(none,V1),(val(none,V2),())).
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=eq,  ARGS = (val(T1,V1),(val(T2,V2),())), (T1;T2) = none, (T1;T2) != none.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=neq, ARGS = (val(none,V1),(val(none,V2),())).
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=neq, ARGS = (val(T1,V1),(val(T2,V2),())), (T1;T2) = none, (T1;T2) != none.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=eq,  ARGS = (val(none,V1),(val(none,V2),())).
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=eq,  ARGS = (val(T1,V1),(val(T2,V2),())), (T1;T2) = none, (T1;T2) != none.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=neq, ARGS = (val(none,V1),(val(none,V2),())).
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=neq, ARGS = (val(T1,V1),(val(T2,V2),())), (T1;T2) = none, (T1;T2) != none.
 
 %%%%%%%%%%%%%%%%% ite
 operator_declare(ite,(bool,(T,(T,()))),T) :-  _type(T), OP = ite.

--- a/src/constraint_handler/data/direct.lp
+++ b/src/constraint_handler/data/direct.lp
@@ -28,45 +28,45 @@ _se_value(E,V) :- direct_query(E), E=variable(X), _se_assign(NAME,E,E2), _se_val
 
 
 
-%%%%%%%%%%%%%%%%% computedIdx operators
+%%%%%%%%%%%%%%%%% _computedIdx operators
 _direct_queryArgsValues(E,OP,ARGS) :- direct_query(E), E=operation(OP,ARGS). % decl operator
 _direct_queryArgsValues(E,OP,ARGS) :- direct_query(E), E=operation(EOP,ARGS), _se_value(EOP,val(function,OP)).
-computeIdx(E,OP) :-_direct_queryArgsValues(E,OP,ARGS).
+_computeIdx(E,OP) :-_direct_queryArgsValues(E,OP,ARGS).
 _direct_compArg(ARGS,IDX,ARG) :- _direct_queryArgsValues(E,OP,ARGS), (IDX,ARG)=@pythonEnumerateElements(ARGS).
-computeIdx(E,IDX,V) :-_direct_queryArgsValues(E,OP,ARGS), _direct_compArg(ARGS,IDX,ARG), _se_value(ARG,V).
-_se_value(E,VO) :- _direct_queryArgsValues(E,OP,ARGS), computedIdx(E,VO).
+_computeIdx(E,IDX,V) :-_direct_queryArgsValues(E,OP,ARGS), _direct_compArg(ARGS,IDX,ARG), _se_value(ARG,V).
+_se_value(E,VO) :- _direct_queryArgsValues(E,OP,ARGS), _computedIdx(E,VO).
 
-%%%%%%%%%%%%%%%%% computed operators
+%%%%%%%%%%%%%%%%% _computed operators
 _direct_queryArgsValues(E,OP,ARGS) :- direct_query(E), E=operation(OP,ARGS). % decl operator
 _direct_queryArgsValues(E,OP,ARGS) :- direct_query(E), E=operation(EOP,ARGS), _se_value(EOP,val(function,OP)).
 %% _direct_compArg(ARGS,IDX,ARG) :- _direct_queryArgsValues(E,OP,ARGS), (IDX,ARG)=@pythonEnumerateElements(ARGS).
 %% _direct_compMapAux(ARGS,N,()) :- _direct_queryArgsValues(E,OP,ARGS), N=@pythonListLength(ARGS).
 %% _direct_compMapAux(ARGS,IDX,K) :- _direct_compMapAux(ARGS,IDX+1,L), _direct_compArg(ARGS,IDX,ARG), _se_value(ARG,T,V), K=(val(T,V),L).
-%% compute(OP,VS) :- _direct_queryArgsValues(E,OP,ARGS), _direct_compMapAux(ARGS,0,VS).
-%% _se_value(E,TO,VO) :- _direct_queryArgsValues(E,OP,ARGS), _direct_compMapAux(ARGS,0,VS), computed(OP,VS,val(TO,VO)).
+%% _compute(OP,VS) :- _direct_queryArgsValues(E,OP,ARGS), _direct_compMapAux(ARGS,0,VS).
+%% _se_value(E,TO,VO) :- _direct_queryArgsValues(E,OP,ARGS), _direct_compMapAux(ARGS,0,VS), _computed(OP,VS,val(TO,VO)).
 _direct_revMapAux(ARGS,ES,()) :- _direct_queryArgsValues(E,OP,ARGS), ES=@pythonReversed(ARGS).
 _direct_revMapAux(ARGS,ES,(V,VS)) :- _direct_revMapAux(ARGS,(E,ES),VS), _se_value(E,V).
-compute(OP,VS) :- _direct_queryArgsValues(E,OP,ARGS), _direct_revMapAux(ARGS,(),VS).
-_se_value(E,VO) :- _direct_queryArgsValues(E,OP,ARGS), _direct_revMapAux(ARGS,(),VS), computed(OP,VS,VO).
+_compute(OP,VS) :- _direct_queryArgsValues(E,OP,ARGS), _direct_revMapAux(ARGS,(),VS).
+_se_value(E,VO) :- _direct_queryArgsValues(E,OP,ARGS), _direct_revMapAux(ARGS,(),VS), _computed(OP,VS,VO).
 
 %%%%%%%%%%%%%%%%% lambda
-_lambda_aux(LAMB,ARGS,RED) :- compute(LAMB,ARGS),
+_lambda_aux(LAMB,ARGS,RED) :- _compute(LAMB,ARGS),
     LAMB=lambda(VARS,ERES),
     RED=@pythonBetaReduction(ERES,VARS,ARGS).
 
 direct_query(RED) :- _lambda_aux(LAMB,ARGS,RED).
-computed(LAMB,ARGS,VO) :- _lambda_aux(LAMB,ARGS,RED), _se_value(RED,VO).
+_computed(LAMB,ARGS,VO) :- _lambda_aux(LAMB,ARGS,RED), _se_value(RED,VO).
 
 %%%%%%%%%%%%%%%%% python
-_direct_implode_arg(OP,ARGS,IDX,ARG) :- compute(OP,ARGS), OP=python(S), (IDX,ARG)=@pythonEnumerateElements(ARGS).
+_direct_implode_arg(OP,ARGS,IDX,ARG) :- _compute(OP,ARGS), OP=python(S), (IDX,ARG)=@pythonEnumerateElements(ARGS).
 _direct_implode(ARG) :- _direct_implode_arg(OP,ARGS,IDX,ARG).
-_direct_implode_args_aux(ARGS,N,()) :- compute(OP,ARGS), OP=python(S), N=@pythonListLength(ARGS).
+_direct_implode_args_aux(ARGS,N,()) :- _compute(OP,ARGS), OP=python(S), N=@pythonListLength(ARGS).
 _direct_implode_args_aux(ARGS,IDX,K) :- _direct_implode_args_aux(ARGS,IDX+1,L),
     _direct_implode_arg(OP,ARGS,IDX,ARG),
     _direct_imploded(ARG,IMP), K=(IMP,L).
-_expression_eval_exec(OP,ARGS,RES) :- compute(OP,ARGS), OP=python(S), _direct_implode_args_aux(ARGS,0,L), RES = @pythonEvalExpr(operation(OP,L),(),ID), _main_solverIdentifier(ID).
-computed(OP,ARGS,val(TYPE,V)) :- _expression_eval_exec(OP,ARGS,val(TYPE,V)).
-computed(OP,ARGS,bad) :- _expression_eval_exec(OP,ARGS,error(KIND,MSG)).
+_expression_eval_exec(OP,ARGS,RES) :- _compute(OP,ARGS), OP=python(S), _direct_implode_args_aux(ARGS,0,L), RES = @pythonEvalExpr(operation(OP,L),(),ID), _main_solverIdentifier(ID).
+_computed(OP,ARGS,val(TYPE,V)) :- _expression_eval_exec(OP,ARGS,val(TYPE,V)).
+_computed(OP,ARGS,bad) :- _expression_eval_exec(OP,ARGS,error(KIND,MSG)).
 _warning(KIND,(),(OP,ARGS,MSG)) :- _expression_eval_exec(OP,ARGS,error(KIND,MSG)).
 %%% TODO duplicated code in groundEval.lp
 

--- a/src/constraint_handler/data/float.lp
+++ b/src/constraint_handler/data/float.lp
@@ -11,13 +11,13 @@ operator_declare(OP,(T,(T,())),float) :- T = int, OP = fdiv.
 operator_declare(OP,(T1,(T2,())),bool) :- T1 = (int;float),T2 = (int;float), (T1,T2) != (int,int), OP = (leq;lt;geq;gt).
 operator_declare(OP,(T,(T,())),bool) :- T = float, OP = (eq;neq).
 
-stageCompute(OP,ARGS,L) :- compute(OP,ARGS), intToFloatOperator(OP), ARGS = (val(int,V),()), L=(V,()).
-stageCompute(OP,ARGS,L) :- compute(OP,ARGS), floatUnOperator(OP), ARGS=(val(float,V),()), L=(V,()).
-stageCompute(OP,ARGS,L) :- compute(OP,ARGS), floatBinOperator(OP), ARGS=(val(T1,V1),(val(T2,V2),())), L=(V1,(V2,())),
+_stageCompute(OP,ARGS,L) :- _compute(OP,ARGS), intToFloatOperator(OP), ARGS = (val(int,V),()), L=(V,()).
+_stageCompute(OP,ARGS,L) :- _compute(OP,ARGS), floatUnOperator(OP), ARGS=(val(float,V),()), L=(V,()).
+_stageCompute(OP,ARGS,L) :- _compute(OP,ARGS), floatBinOperator(OP), ARGS=(val(T1,V1),(val(T2,V2),())), L=(V1,(V2,())),
     (T1;T2)=float, T1=(float;int), T2=(float;int).
-stageCompute(OP,ARGS,L) :- compute(OP,ARGS), OP=(eq;neq), ARGS=(val(T1,V1),(val(T2,V2),())), L=(V1,(V2,())),
+_stageCompute(OP,ARGS,L) :- _compute(OP,ARGS), OP=(eq;neq), ARGS=(val(T1,V1),(val(T2,V2),())), L=(V1,(V2,())),
     T1=float, T2=float.
 
-_expression_eval_exec(OP,ARGS,RES) :- stageCompute(OP,ARGS,L), RES = @pythonEvalExpr(operation(OP,ARGS),(),ID), _main_solverIdentifier(ID).
-computed(OP,ARGS,val(TYPE,V)) :- _expression_eval_exec(OP,ARGS,val(TYPE,V)).
+_expression_eval_exec(OP,ARGS,RES) :- _stageCompute(OP,ARGS,L), RES = @pythonEvalExpr(operation(OP,ARGS),(),ID), _main_solverIdentifier(ID).
+_computed(OP,ARGS,val(TYPE,V)) :- _expression_eval_exec(OP,ARGS,val(TYPE,V)).
 _warning(KIND,(),(OP,ARGS,MSG)) :- _expression_eval_exec(OP,ARGS,error(KIND,MSG)).

--- a/src/constraint_handler/data/int.lp
+++ b/src/constraint_handler/data/int.lp
@@ -1,49 +1,49 @@
 %%%%%%%%%%%%%%%%% add mult
 operator_declare_variadic(OP,T,T,1) :- T = int, OP = (add;mult).
-computed(OP, ARGS, val(int, 0)) :- compute(OP, ARGS), OP=add, ARGS = ().
-compute(OP, TAIL) :- compute(OP, ARGS), OP=add, ARGS = (val(int, _), TAIL).
-computed(OP, ARGS, val(int, V1 + VTAIL)) :-
-    compute(OP, ARGS),
+_computed(OP, ARGS, val(int, 0)) :- _compute(OP, ARGS), OP=add, ARGS = ().
+_compute(OP, TAIL) :- _compute(OP, ARGS), OP=add, ARGS = (val(int, _), TAIL).
+_computed(OP, ARGS, val(int, V1 + VTAIL)) :-
+    _compute(OP, ARGS),
     OP=add,
     ARGS = (val(int, V1), TAIL),
-    computed(OP, TAIL, val(int, VTAIL)).
+    _computed(OP, TAIL, val(int, VTAIL)).
 
-computed(OP, ARGS, val(int, 1)) :- compute(OP, ARGS), OP=mult, ARGS = ().
-compute(OP, TAIL) :- compute(OP, ARGS), OP=mult, ARGS = (val(int, _), TAIL).
-computed(OP, ARGS, val(int, V1 * VTAIL)) :-
-    compute(OP, ARGS),
+_computed(OP, ARGS, val(int, 1)) :- _compute(OP, ARGS), OP=mult, ARGS = ().
+_compute(OP, TAIL) :- _compute(OP, ARGS), OP=mult, ARGS = (val(int, _), TAIL).
+_computed(OP, ARGS, val(int, V1 * VTAIL)) :-
+    _compute(OP, ARGS),
     OP=mult,
     ARGS = (val(int, V1), TAIL),
-    computed(OP, TAIL, val(int, VTAIL)).
+    _computed(OP, TAIL, val(int, VTAIL)).
 
 %%%%%%%%%%%%%%%%% sub div pow
 operator_declare(OP,(T,(T,())),T) :- T = int, OP = (sub;div;pow).
-computed(OP,ARGS,val(int,V1-V2))  :- compute(OP,ARGS), OP=sub,  ARGS = (val(int,V1),(val(int,V2),())).
-computed(OP,ARGS,val(int,V1/V2))  :- compute(OP,ARGS), OP=div,  ARGS = (val(int,V1),(val(int,V2),())), V2!=0.
-computed(OP,ARGS,bad) :- compute(OP,ARGS), OP=(div;fdiv),  ARGS = (val(int,V1),(val(int,V2),())), V2=0.
-warning(expression(zeroDivisionError),(),(OP,ARGS))  :- compute(OP,ARGS), OP=(div;fdiv),  ARGS = (val(int,V1),(val(int,V2),())), V2=0.
-computed(OP,ARGS,val(int,V1**V2)) :- compute(OP,ARGS), OP=pow,  ARGS = (val(int,V1),(val(int,V2),())).
+_computed(OP,ARGS,val(int,V1-V2))  :- _compute(OP,ARGS), OP=sub,  ARGS = (val(int,V1),(val(int,V2),())).
+_computed(OP,ARGS,val(int,V1/V2))  :- _compute(OP,ARGS), OP=div,  ARGS = (val(int,V1),(val(int,V2),())), V2!=0.
+_computed(OP,ARGS,bad) :- _compute(OP,ARGS), OP=(div;fdiv),  ARGS = (val(int,V1),(val(int,V2),())), V2=0.
+warning(expression(zeroDivisionError),(),(OP,ARGS))  :- _compute(OP,ARGS), OP=(div;fdiv),  ARGS = (val(int,V1),(val(int,V2),())), V2=0.
+_computed(OP,ARGS,val(int,V1**V2)) :- _compute(OP,ARGS), OP=pow,  ARGS = (val(int,V1),(val(int,V2),())).
 
 %%%%%%%%%%%%%%%%% abs minus
 operator_declare(OP,(T,()),T) :- T = int, OP = (abs;minus).
-computed(OP,ARGS,val(int,|V|)) :- compute(OP,ARGS), OP=abs,   ARGS = (val(int,V),()).
-computed(OP,ARGS,val(int,-V))  :- compute(OP,ARGS), OP=minus, ARGS = (val(int,V),()).
+_computed(OP,ARGS,val(int,|V|)) :- _compute(OP,ARGS), OP=abs,   ARGS = (val(int,V),()).
+_computed(OP,ARGS,val(int,-V))  :- _compute(OP,ARGS), OP=minus, ARGS = (val(int,V),()).
 
 %%%%%%%%%%%%%%%%% comparison equality
 operator_declare(OP,(T,(T,())),bool) :- T = int, OP = (eq;neq;leq;lt;geq;gt).
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=eq,  ARGS = (val(int,V1),(val(int,V2),())), V1 =  V2.
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=neq, ARGS = (val(int,V1),(val(int,V2),())), V1 != V2.
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=leq, ARGS = (val(int,V1),(val(int,V2),())), V1 <= V2.
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=lt,  ARGS = (val(int,V1),(val(int,V2),())), V1 <  V2.
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=geq, ARGS = (val(int,V1),(val(int,V2),())), V1 >= V2.
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=gt,  ARGS = (val(int,V1),(val(int,V2),())), V1 >  V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=eq,  ARGS = (val(int,V1),(val(int,V2),())), V1 != V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=neq, ARGS = (val(int,V1),(val(int,V2),())), V1 =  V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=leq, ARGS = (val(int,V1),(val(int,V2),())), V1 >  V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=lt,  ARGS = (val(int,V1),(val(int,V2),())), V1 >= V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=geq, ARGS = (val(int,V1),(val(int,V2),())), V1 <  V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=gt,  ARGS = (val(int,V1),(val(int,V2),())), V1 <= V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=eq,  ARGS = (val(int,V1),(val(int,V2),())), V1 =  V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=neq, ARGS = (val(int,V1),(val(int,V2),())), V1 != V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=leq, ARGS = (val(int,V1),(val(int,V2),())), V1 <= V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=lt,  ARGS = (val(int,V1),(val(int,V2),())), V1 <  V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=geq, ARGS = (val(int,V1),(val(int,V2),())), V1 >= V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=gt,  ARGS = (val(int,V1),(val(int,V2),())), V1 >  V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=eq,  ARGS = (val(int,V1),(val(int,V2),())), V1 != V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=neq, ARGS = (val(int,V1),(val(int,V2),())), V1 =  V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=leq, ARGS = (val(int,V1),(val(int,V2),())), V1 >  V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=lt,  ARGS = (val(int,V1),(val(int,V2),())), V1 >= V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=geq, ARGS = (val(int,V1),(val(int,V2),())), V1 <  V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=gt,  ARGS = (val(int,V1),(val(int,V2),())), V1 <= V2.
 
-computed(OP,ARGS,RES) :- compute(OP,ARGS), OP=fdiv, ARGS = (val(int,_),(val(int,V2),())), V2!=0,
+_computed(OP,ARGS,RES) :- _compute(OP,ARGS), OP=fdiv, ARGS = (val(int,_),(val(int,V2),())), V2!=0,
   RES = @pythonEvalExpr(operation(OP,ARGS),(),ID),
   _main_solverIdentifier(ID).

--- a/src/constraint_handler/data/main.lp
+++ b/src/constraint_handler/data/main.lp
@@ -2,7 +2,7 @@
 % #include "gringoEval.lp".
 % #include "display.lp".
 
-#defined computed/4.
+#defined _computed/4.
 #defined requestEngine/2.
 #defined defaultEngine/1.
 #defined main_solverIdentifier/1.

--- a/src/constraint_handler/data/multimap.lp
+++ b/src/constraint_handler/data/multimap.lp
@@ -26,13 +26,13 @@ _multimap_add(ER,EK,EV) :- direct_query(E), E=operation(multimap_make,L), _se_va
 
 _multimap_has(key,EM,K) :- _multimap_add(EM,EK,EV), _se_value(EK,K).
 
-compute(eq,(V1,(V2,()))) :- _multimap_has(D,E,V1), _multimap_has(D,E,V2), V1 <= V2.
+_compute(eq,(V1,(V2,()))) :- _multimap_has(D,E,V1), _multimap_has(D,E,V2), V1 <= V2.
 _multimap_has(val(R),EM,V) :- _multimap_add(EM,EK,EV),
     _se_value(EK,K), _se_value(EV,V),
     _multimap_representative(key,EM,K,R).
 _multimap_representative(D,E,V,R) :- _multimap_has(D,E,V),
-    _multimap_has(D,E,R), R <= V, computed(eq,(R,(V,())),val(bool,true)),
-    #false: _multimap_has(D,E,W), W < R, computed(eq,(W,(R,())),val(bool,true)).
+    _multimap_has(D,E,R), R <= V, _computed(eq,(R,(V,())),val(bool,true)),
+    #false: _multimap_has(D,E,W), W < R, _computed(eq,(W,(R,())),val(bool,true)).
 
 _multimap_entry(EM,RK,RV) :- _multimap_add(EM,EK,EV),
     _se_value(EK,K), _multimap_representative(key,EM,K,RK),
@@ -45,28 +45,28 @@ multimap_value(X,KEY,VAL) :- _se_value(E,val(multimap,EM)), _multimap_entry(EM,K
 %%%%%%%%%%%%%%%%%% find
 operator_declare(OP,(T1,(T2,())),set) :- _type(T1), T2 = multimap, OP = find.
 %%% TODO: this is fragile, maybe buggy.
-computed(O,ARGS,ref(set,find(ARGS))) :- compute(O,ARGS), O=find, ARGS=(K,(val(multimap,EM),())).
+_computed(O,ARGS,ref(set,find(ARGS))) :- _compute(O,ARGS), O=find, ARGS=(K,(val(multimap,EM),())).
 
-_set_contains(ER,V) :- compute(O,ARGS), O=find, computed(O,ARGS,ref(set,ER)),
+_set_contains(ER,V) :- _compute(O,ARGS), O=find, _computed(O,ARGS,ref(set,ER)),
     ARGS=(K,(val(multimap,EM),())),
     _multimap_entry(EM,K,V).
 
 %%%%%%%%%%%%%%%%%% count keys and entries
 operator_declare(OP,(T,()),int) :- T = multimap, OP = (countKeys;countEntries;sumIntEntries).
-computed(O,ARGS,val(int,N)) :- compute(O,ARGS), O=countKeys, ARGS=(val(multimap,EM),()),
+_computed(O,ARGS,val(int,N)) :- _compute(O,ARGS), O=countKeys, ARGS=(val(multimap,EM),()),
     N = #count { K : _multimap_entry(EM,K,V) }.
 
-computed(O,ARGS,val(int,N)) :- compute(O,ARGS), O=countEntries, ARGS=(val(multimap,EM),()),
+_computed(O,ARGS,val(int,N)) :- _compute(O,ARGS), O=countEntries, ARGS=(val(multimap,EM),()),
     N = #count { K,V : _multimap_entry(EM,K,V) }.
 
-computed(O,ARGS,val(int,N)) :- compute(O,ARGS), O=sumIntEntries, ARGS=(val(multimap,EM),()),
+_computed(O,ARGS,val(int,N)) :- _compute(O,ARGS), O=sumIntEntries, ARGS=(val(multimap,EM),()),
     N = #sum { RV,K : _multimap_entry(EM,K,val(int,RV)) }.
 
 %%%% TODO use type-specific greater/smaller than, instead of gringo's ordering.
-computed(O,ARGS,M) :- compute(O,ARGS), O=maxEntries, ARGS=(val(multimap,EM),()),
+_computed(O,ARGS,M) :- _compute(O,ARGS), O=maxEntries, ARGS=(val(multimap,EM),()),
     M = #max { V : _multimap_entry(EM,K,V) }.
 
-computed(O,ARGS,M) :- compute(O,ARGS), O=minEntries, ARGS=(val(multimap,EM),()),
+_computed(O,ARGS,M) :- _compute(O,ARGS), O=minEntries, ARGS=(val(multimap,EM),()),
     M = #min { V : _multimap_entry(EM,K,V) }.
 
 %%%%%%%%%%%%%%%%%% isin notin
@@ -75,23 +75,23 @@ computed(O,ARGS,M) :- compute(O,ARGS), O=minEntries, ARGS=(val(multimap,EM),()),
 
 %%%%%%%%%%%%%%%%%% Equality
 operator_declare(OP,(T,(T,())),bool) :- T = multimap, OP = (eq;neq).
-compute(eq,ARGS) :- compute(neq,ARGS), ARGS = (val(multimap,M1),(val(multimap,M2),())).
-computed(neq,ARGS,val(bool,NEQ)) :- computed(eq,ARGS,val(bool,EQ)), ARGS = (val(T1,M1),(val(T2,M2),())), (T1;T2)=multimap, (EQ,NEQ)=((true,false);(false,true)).
-computed(eq,ARGS,val(bool,true))  :- compute(eq,ARGS),  ARGS = (val(multimap,S1),(val(multimap,S2),())), not computed(eq,ARGS,val(bool,false)).
+_compute(eq,ARGS) :- _compute(neq,ARGS), ARGS = (val(multimap,M1),(val(multimap,M2),())).
+_computed(neq,ARGS,val(bool,NEQ)) :- _computed(eq,ARGS,val(bool,EQ)), ARGS = (val(T1,M1),(val(T2,M2),())), (T1;T2)=multimap, (EQ,NEQ)=((true,false);(false,true)).
+_computed(eq,ARGS,val(bool,true))  :- _compute(eq,ARGS),  ARGS = (val(multimap,S1),(val(multimap,S2),())), not _computed(eq,ARGS,val(bool,false)).
 
-computed(eq,ARGS,val(bool,false)) :- compute(eq,ARGS), ARGS = (val(multimap,M1),(val(multimap,M2),())),
+_computed(eq,ARGS,val(bool,false)) :- _compute(eq,ARGS), ARGS = (val(multimap,M1),(val(multimap,M2),())),
     _multimap_entry(M1,K1,V1),
-    #false : _multimap_entry(M2,K2,V2), computed(eq,(K1,(K2,())),val(bool,true)), computed(eq,(V1,(V2,())),val(bool,true)).
-computed(eq,ARGS,val(bool,false)) :- compute(eq,ARGS), ARGS = (val(multimap,M1),(val(multimap,M2),())),
+    #false : _multimap_entry(M2,K2,V2), _computed(eq,(K1,(K2,())),val(bool,true)), _computed(eq,(V1,(V2,())),val(bool,true)).
+_computed(eq,ARGS,val(bool,false)) :- _compute(eq,ARGS), ARGS = (val(multimap,M1),(val(multimap,M2),())),
     _multimap_entry(M2,K2,V2),
-    #false : _multimap_entry(M1,K1,V1), computed(eq,(K1,(K2,())),val(bool,true)), computed(eq,(V1,(V2,())),val(bool,true)).
+    #false : _multimap_entry(M1,K1,V1), _computed(eq,(K1,(K2,())),val(bool,true)), _computed(eq,(V1,(V2,())),val(bool,true)).
 
 
-compute(eq,SUBARGS) :- compute(eq,ARGS), ARGS = (val(multimap,M1),(val(multimap,M2),())),
+_compute(eq,SUBARGS) :- _compute(eq,ARGS), ARGS = (val(multimap,M1),(val(multimap,M2),())),
     _multimap_entry(M1,K1,V1),
     _multimap_entry(M2,K2,V2),
     SUBARGS=(K1,(K2,())).
-compute(eq,SUBARGS) :- compute(eq,ARGS), ARGS = (val(multimap,M1),(val(multimap,M2),())),
+_compute(eq,SUBARGS) :- _compute(eq,ARGS), ARGS = (val(multimap,M1),(val(multimap,M2),())),
     _multimap_entry(M1,K1,V1),
     _multimap_entry(M2,K2,V2),
     SUBARGS=(V1,(V2,())).
@@ -99,16 +99,16 @@ compute(eq,SUBARGS) :- compute(eq,ARGS), ARGS = (val(multimap,M1),(val(multimap,
 %%%%%%%%%%%%%%%%%% Fold
 %%% fold: a -> b -> b
 
-_multimap_makeIndex(VM) :- compute(multimap_fold,ARGS), ARGS = (val(function,VO),(val(multimap,VM),(ACC,()))).
-_multimap_foldStep(multimap_fold,ARGS,0,ACC) :- compute(multimap_fold,ARGS), ARGS = (val(function,VO),(val(multimap,VM),(ACC,()))).
-compute(VO,SUBARGS) :- compute(multimap_fold,ARGS), ARGS = (val(function,VO),(val(multimap,VM),(START,()))),
+_multimap_makeIndex(VM) :- _compute(multimap_fold,ARGS), ARGS = (val(function,VO),(val(multimap,VM),(ACC,()))).
+_multimap_foldStep(multimap_fold,ARGS,0,ACC) :- _compute(multimap_fold,ARGS), ARGS = (val(function,VO),(val(multimap,VM),(ACC,()))).
+_compute(VO,SUBARGS) :- _compute(multimap_fold,ARGS), ARGS = (val(function,VO),(val(multimap,VM),(START,()))),
     _multimap_index(VM,I,K,VI), _multimap_foldStep(multimap_fold,ARGS,I,VB),
     SUBARGS = (VI,(VB,())).
-_multimap_foldStep(multimap_fold,ARGS,I+1,NEXT) :- compute(multimap_fold,ARGS), ARGS = (val(function,VO),(val(multimap,VM),(START,()))),
+_multimap_foldStep(multimap_fold,ARGS,I+1,NEXT) :- _compute(multimap_fold,ARGS), ARGS = (val(function,VO),(val(multimap,VM),(START,()))),
     _multimap_foldStep(multimap_fold,ARGS,I,VB), _multimap_index(VM,I,K,VI),
     SUBARGS = (VI,(VB,())),
-    computed(VO,SUBARGS,NEXT).
-computed(multimap_fold,ARGS,VB) :- compute(multimap_fold,ARGS), ARGS = (val(function,VO),(val(multimap,VM),(START,()))),
+    _computed(VO,SUBARGS,NEXT).
+_computed(multimap_fold,ARGS,VB) :- _compute(multimap_fold,ARGS), ARGS = (val(function,VO),(val(multimap,VM),(START,()))),
     _multimap_foldStep(multimap_fold,ARGS,I,VB),
     _multimap_lastIndex(VM,I).
 
@@ -128,7 +128,7 @@ _multimap_lastIndex(EM,0) :- _multimap_makeIndex(EM),
 
 %%%%%%%%%%%%%%%%%% isin
 operator_declare(OP,(T1,(T2,())),bool) :- _type(T1),T2=multimap, OP = (isin).
-computed(O,ARGS,val(bool,true)) :- compute(O,ARGS), O=isin, ARGS=(K,(val(multimap,EM),())),
+_computed(O,ARGS,val(bool,true)) :- _compute(O,ARGS), O=isin, ARGS=(K,(val(multimap,EM),())),
     _multimap_entry(EM,K,V).
-computed(O,ARGS,val(bool,false)) :- compute(O,ARGS), O=isin, ARGS=(K,(val(multimap,EM),())),
+_computed(O,ARGS,val(bool,false)) :- _compute(O,ARGS), O=isin, ARGS=(K,(val(multimap,EM),())),
     #false : _multimap_entry(EM,K,V).

--- a/src/constraint_handler/data/set.lp
+++ b/src/constraint_handler/data/set.lp
@@ -12,7 +12,7 @@ representation(set,intensional).
 
 %%%%%%%%%%%%%%%%% length
 operator_declare(OP,(T,()),int) :- T = set, OP = length.
-computed(length,ARGS,val(int,N)) :- compute(length,ARGS),
+_computed(length,ARGS,val(int,N)) :- _compute(length,ARGS),
     ARGS = (ref(set,SET),()),
     N = #count { V : _set_contains(SET,V) }.
 
@@ -20,12 +20,12 @@ computed(length,ARGS,val(int,N)) :- compute(length,ARGS),
 
 _se_value(EX,ref(set,EX)) :- _set_declare(NAME,EX).
 
-compute(eq,(V1,(V2,()))) :-
+_compute(eq,(V1,(V2,()))) :-
     _set_assign(N1,EX,E1), _se_value(E1,V1),
     _set_assign(N2,EX,E2), _se_value(E2,V2), V1 < V2.
 _set_contains(EX,V1) :-
     _set_assign(NAME,EX,E1), _se_value(E1,V1), %_se_value(EX,ref(set,ER)),
-    #false : _set_assign(N2,EX,E2), _se_value(E2,V2), computed(eq,(V2,(V1,())),val(bool,true)), V2 < V1.
+    #false : _set_assign(N2,EX,E2), _se_value(E2,V2), _computed(eq,(V2,(V1,())),val(bool,true)), V2 < V1.
 
 _set_assign(NAME,EX,S) :- _set_assign(NAME,EX,ER), ER=ref(set,S).
 
@@ -33,17 +33,17 @@ set_value(X,V) :- _se_value(EX,ref(set,E)), _set_contains(E,V), EX=variable(X).
 
 %%%%%%%%%%%%%%%%% isin notin
 operator_declare(OP,(T1,(T2,())),bool) :- _type(T1),T2=set, OP = (isin;notin).
-compute(eq,(V1,(V2,())))  :- compute((isin;notin),ARGS), ARGS = (V1,(ref(set,S),())),
+_compute(eq,(V1,(V2,())))  :- _compute((isin;notin),ARGS), ARGS = (V1,(ref(set,S),())),
     _set_contains(S,V2).
 
-computed(isin,ARGS,val(bool,true))   :- compute(isin,ARGS), ARGS = (V1,(ref(set,S),())),
-    _set_contains(S,V2), computed(eq,(V1,(V2,())),val(bool,true)).
-computed(isin,ARGS,val(bool,false))  :- compute(isin,ARGS), ARGS = (V1,(ref(set,S),())),
-    #false : _set_contains(S,V2), computed(eq,(V1,(V2,())),val(bool,true)).
-computed(notin,ARGS,val(bool,false)) :- compute(notin,ARGS), ARGS = (V1,(ref(set,S),())),
-    _set_contains(S,V2), computed(eq,(V1,(V2,())),val(bool,true)).
-computed(notin,ARGS,val(bool,true))  :- compute(notin,ARGS), ARGS = (V1,(ref(set,S),())),
-    #false : _set_contains(S,V2), computed(eq,(V1,(V2,())),val(bool,true)).
+_computed(isin,ARGS,val(bool,true))   :- _compute(isin,ARGS), ARGS = (V1,(ref(set,S),())),
+    _set_contains(S,V2), _computed(eq,(V1,(V2,())),val(bool,true)).
+_computed(isin,ARGS,val(bool,false))  :- _compute(isin,ARGS), ARGS = (V1,(ref(set,S),())),
+    #false : _set_contains(S,V2), _computed(eq,(V1,(V2,())),val(bool,true)).
+_computed(notin,ARGS,val(bool,false)) :- _compute(notin,ARGS), ARGS = (V1,(ref(set,S),())),
+    _set_contains(S,V2), _computed(eq,(V1,(V2,())),val(bool,true)).
+_computed(notin,ARGS,val(bool,true))  :- _compute(notin,ARGS), ARGS = (V1,(ref(set,S),())),
+    #false : _set_contains(S,V2), _computed(eq,(V1,(V2,())),val(bool,true)).
 
 %%%%%%%%%%%%%%%%% makeSet
 operator_declare_variadic(makeSet, T, set, 1) :- _type(T).
@@ -64,7 +64,7 @@ operator_declare(OP,(T,(T,())),T) :- T = set, OP = (union;inter;diff).
 _set_declare(_internal,E) :- direct_query(E), E=operation((diff;inter;union),L).
 _set_assign(_internal,E,V) :- direct_query(E), E=operation(union,L), SE=@pythonListElements(L), _se_value(SE,ref(set,ER)), _set_contains(ER,V).
 
-compute(eq,(VSMALL,(VBIG,()))) :- direct_query(E), E=operation((diff;inter),L), L=(S1,(S2,())),
+_compute(eq,(VSMALL,(VBIG,()))) :- direct_query(E), E=operation((diff;inter),L), L=(S1,(S2,())),
     _se_value(S1,ref(set,R1)), _se_value(S2,ref(set,R2)),
     _set_contains(R1,V1),
     _set_contains(R2,V2),
@@ -73,43 +73,43 @@ compute(eq,(VSMALL,(VBIG,()))) :- direct_query(E), E=operation((diff;inter),L), 
 _set_assign(_internal,E,VSMALL) :- direct_query(E), E=operation(inter,L), L=(S1,(S2,())),
     _se_value(S1,ref(set,R1)), _se_value(S2,ref(set,R2)),
     _set_contains(R1,V1),
-    _set_contains(R2,V2), computed(eq,(VSMALL,(VBIG,())),val(bool,true)),
+    _set_contains(R2,V2), _computed(eq,(VSMALL,(VBIG,())),val(bool,true)),
     (VSMALL,VBIG)=((V1,V2);(V2,V1)), VSMALL <= VBIG.
 
 _set_assign(_internal,E,V1) :- direct_query(E), E=operation(diff,L), L=(S1,(S2,())),
     _se_value(S1,ref(set,R1)), _se_value(S2,ref(set,R2)),
     _set_contains(R1,V1),
-    #false : _set_contains(R2,V2), computed(eq,(VSMALL,(VBIG,())),val(bool,true)),
+    #false : _set_contains(R2,V2), _computed(eq,(VSMALL,(VBIG,())),val(bool,true)),
     (VSMALL,VBIG)=((V1,V2);(V2,V1)), VSMALL <= VBIG.
 
 %%%%%%%%%%%%%%%%% Equality
 operator_declare(OP,(T,(T,())),bool) :- T = set, OP = (eq;neq).
-compute(eq,ARGS) :- compute(neq,ARGS), ARGS = (set(T1,S1),(set(T2,S2),())), (T1;T2)=set.
-computed(neq,ARGS,val(bool,NEQ)) :- computed(eq,ARGS,val(bool,EQ)), ARGS = (ref(T1,S1),(ref(T2,S2),())), (T1;T2)=set, (EQ,NEQ)=((true,false);(false,true)).
+_compute(eq,ARGS) :- _compute(neq,ARGS), ARGS = (set(T1,S1),(set(T2,S2),())), (T1;T2)=set.
+_computed(neq,ARGS,val(bool,NEQ)) :- _computed(eq,ARGS,val(bool,EQ)), ARGS = (ref(T1,S1),(ref(T2,S2),())), (T1;T2)=set, (EQ,NEQ)=((true,false);(false,true)).
 
-computed(eq,ARGS,val(bool,true))  :- compute(eq,ARGS),  ARGS = (ref(set,S1),(ref(set,S2),())), not computed(eq,ARGS,val(bool,false)).
+_computed(eq,ARGS,val(bool,true))  :- _compute(eq,ARGS),  ARGS = (ref(set,S1),(ref(set,S2),())), not _computed(eq,ARGS,val(bool,false)).
 
-computed(eq,ARGS,val(bool,false)) :- compute(eq,ARGS),  ARGS = (ref(set,S1),(val(T2,S2),())), T2 != set.
-computed(eq,ARGS,val(bool,false)) :- compute(eq,ARGS),  ARGS = (val(T1,S1),(ref(set,S2),())), T1 != set.
+_computed(eq,ARGS,val(bool,false)) :- _compute(eq,ARGS),  ARGS = (ref(set,S1),(val(T2,S2),())), T2 != set.
+_computed(eq,ARGS,val(bool,false)) :- _compute(eq,ARGS),  ARGS = (val(T1,S1),(ref(set,S2),())), T1 != set.
 
-computed(eq,ARGS,val(bool,false)) :- compute(eq,ARGS), ARGS=(ref(set,S1),(ref(set,S2),())),
+_computed(eq,ARGS,val(bool,false)) :- _compute(eq,ARGS), ARGS=(ref(set,S1),(ref(set,S2),())),
     _set_contains(S1,V1),
-    #false : _set_contains(S2,V2), computed(eq,(V1,(V2,())),val(bool,true)).
-computed(eq,ARGS,val(bool,false)) :- compute(eq,ARGS), ARGS=(ref(set,S1),(ref(set,S2),())),
+    #false : _set_contains(S2,V2), _computed(eq,(V1,(V2,())),val(bool,true)).
+_computed(eq,ARGS,val(bool,false)) :- _compute(eq,ARGS), ARGS=(ref(set,S1),(ref(set,S2),())),
     _set_contains(S2,V2),
-    #false : _set_contains(S1,V1), computed(eq,(V1,(V2,())),val(bool,true)).
+    #false : _set_contains(S1,V1), _computed(eq,(V1,(V2,())),val(bool,true)).
 
-compute(eq,(V1,(V2,()))) :- compute(eq,ARGS), ARGS=(ref(set,S1),(ref(set,S2),())),
+_compute(eq,(V1,(V2,()))) :- _compute(eq,ARGS), ARGS=(ref(set,S1),(ref(set,S2),())),
     _set_contains(S1,V1), _set_contains(S2,V2).
 
 %%%%%%%%%%%%%%%%% Equality axioms
 
-:- computed(eq,(ref(set,X),(ref(set,X),())),val(bool,false)). %%% reflexivity
-:- computed(eq,(ref(set,X),(ref(set,Y),())),val(bool,true)),
-   computed(eq,(ref(set,Y),(ref(set,X),())),val(bool,false)). %%% symmetry
-:- computed(eq,(ref(set,L1),(ref(set,R1),())),val(bool,true)),
-   computed(eq,(ref(set,L2),(ref(set,R2),())),val(bool,true)),
-   computed(eq,(ref(set,L3),(ref(set,R3),())),val(bool,false)),
+:- _computed(eq,(ref(set,X),(ref(set,X),())),val(bool,false)). %%% reflexivity
+:- _computed(eq,(ref(set,X),(ref(set,Y),())),val(bool,true)),
+   _computed(eq,(ref(set,Y),(ref(set,X),())),val(bool,false)). %%% symmetry
+:- _computed(eq,(ref(set,L1),(ref(set,R1),())),val(bool,true)),
+   _computed(eq,(ref(set,L2),(ref(set,R2),())),val(bool,true)),
+   _computed(eq,(ref(set,L3),(ref(set,R3),())),val(bool,false)),
     X=(L1;R1), Y=(L1;R1),
     Y=(L2;R2), Z=(L2;R2),
     X=(L3;R3), Z=(L3;R3),
@@ -117,30 +117,30 @@ compute(eq,(V1,(V2,()))) :- compute(eq,ARGS), ARGS=(ref(set,S1),(ref(set,S2),())
 
 %%%%%%%%%%%%%%%%% Subset
 operator_declare(OP,(T,(T,())),bool) :- T = (set), OP = subset.
-compute(eq,(V1,(V2,()))) :- compute(subset,ARGS), ARGS = (ref(set,S1),(ref(set,S2),())),
+_compute(eq,(V1,(V2,()))) :- _compute(subset,ARGS), ARGS = (ref(set,S1),(ref(set,S2),())),
     _set_contains(S1,V1), _set_contains(S2,V2).
-computed(subset,ARGS,val(bool,false)) :- compute(subset,ARGS), ARGS = (ref(set,S1),(ref(set,S2),())),
+_computed(subset,ARGS,val(bool,false)) :- _compute(subset,ARGS), ARGS = (ref(set,S1),(ref(set,S2),())),
     _set_contains(S1,V1),
-    #false : _set_contains(S2,V2), computed(eq,(V1,(V2,())),val(bool,true)).
+    #false : _set_contains(S2,V2), _computed(eq,(V1,(V2,())),val(bool,true)).
 
-computed(subset,ARGS,val(bool,true))  :- compute(subset,ARGS), ARGS = (ref(set,S1),(ref(set,S2),())),
-    not computed(subset,ARGS,val(bool,false)).
-computed(subset,ARGS,val(bool,false)) :- compute(subset,ARGS), ARGS = (val(T1,S1),(val(T2,S2),())),
+_computed(subset,ARGS,val(bool,true))  :- _compute(subset,ARGS), ARGS = (ref(set,S1),(ref(set,S2),())),
+    not _computed(subset,ARGS,val(bool,false)).
+_computed(subset,ARGS,val(bool,false)) :- _compute(subset,ARGS), ARGS = (val(T1,S1),(val(T2,S2),())),
     (T1;T2) != set, (T1;T2) = set.
 
 %%%%%%%%%%%%%%%%%% Fold
 %%% set_fold: a -> b -> b
 
-_set_makeIndex(VM) :- compute(set_fold,ARGS), ARGS = (val(function,VO),(ref(set,VM),(ACC,()))).
-_set_foldStep(set_fold,ARGS,0,ACC) :- compute(set_fold,ARGS), ARGS = (val(function,VO),(ref(set,VM),(ACC,()))).
-compute(VO,SUBARGS) :- compute(set_fold,ARGS), ARGS = (val(function,VO),(ref(set,VM),(ACC,()))),
+_set_makeIndex(VM) :- _compute(set_fold,ARGS), ARGS = (val(function,VO),(ref(set,VM),(ACC,()))).
+_set_foldStep(set_fold,ARGS,0,ACC) :- _compute(set_fold,ARGS), ARGS = (val(function,VO),(ref(set,VM),(ACC,()))).
+_compute(VO,SUBARGS) :- _compute(set_fold,ARGS), ARGS = (val(function,VO),(ref(set,VM),(ACC,()))),
     _set_index(VM,I,VI), _set_foldStep(set_fold,ARGS,I,VB),
     SUBARGS = (VI,(VB,())).
-_set_foldStep(set_fold,ARGS,I+1,NEXT) :- compute(set_fold,ARGS), ARGS = (val(function,VO),(ref(set,VM),(START,()))),
+_set_foldStep(set_fold,ARGS,I+1,NEXT) :- _compute(set_fold,ARGS), ARGS = (val(function,VO),(ref(set,VM),(START,()))),
     _set_foldStep(set_fold,ARGS,I,VB), _set_index(VM,I,VI),
     SUBARGS = (VI,(VB,())),
-    computed(VO,SUBARGS,NEXT).
-computed(set_fold,ARGS,VB) :- compute(set_fold,ARGS), ARGS = (val(function,VO),(ref(set,VM),(START,()))),
+    _computed(VO,SUBARGS,NEXT).
+_computed(set_fold,ARGS,VB) :- _compute(set_fold,ARGS), ARGS = (val(function,VO),(ref(set,VM),(START,()))),
     _set_foldStep(set_fold,ARGS,I,VB),
     _set_lastIndex(VM,I).
 

--- a/src/constraint_handler/data/string.lp
+++ b/src/constraint_handler/data/string.lp
@@ -1,15 +1,15 @@
 %%%%%%%%%%%%%%%%% eq neq
 operator_declare(OP,(T,(T,())),bool) :- T = str, OP = (eq;neq).
-computed(O,ARGS,val(bool,true))  :- compute(O,ARGS), O=eq,  ARGS = (val(str,S1),(val(str,S2),())), S1 =  S2.
-computed(O,ARGS,val(bool,true))  :- compute(O,ARGS), O=neq, ARGS = (val(str,S1),(val(str,S2),())), S1 != S2.
-computed(O,ARGS,val(bool,false)) :- compute(O,ARGS), O=eq,  ARGS = (val(str,S1),(val(str,S2),())), S1 != S2.
-computed(O,ARGS,val(bool,false)) :- compute(O,ARGS), O=neq, ARGS = (val(str,S1),(val(str,S2),())), S1 =  S2.
+_computed(O,ARGS,val(bool,true))  :- _compute(O,ARGS), O=eq,  ARGS = (val(str,S1),(val(str,S2),())), S1 =  S2.
+_computed(O,ARGS,val(bool,true))  :- _compute(O,ARGS), O=neq, ARGS = (val(str,S1),(val(str,S2),())), S1 != S2.
+_computed(O,ARGS,val(bool,false)) :- _compute(O,ARGS), O=eq,  ARGS = (val(str,S1),(val(str,S2),())), S1 != S2.
+_computed(O,ARGS,val(bool,false)) :- _compute(O,ARGS), O=neq, ARGS = (val(str,S1),(val(str,S2),())), S1 =  S2.
 
 %%%%%%%%%%%%%%%%% length concat
 operator_declare(OP,(T,()),int) :- T = str, OP = length.
 operator_declare(OP,(T,(T,())),T) :- T = str, OP = concat.
-computed(O,ARGS,val(int,N)) :- compute(O,ARGS), O=length, ARGS = (val(str,S),()), N=@pythonStringLength(S).
-computed(O,ARGS,val(str,R)) :- compute(O,ARGS), O=concat, ARGS = (val(str,S1),(val(str,S2),())), R=@pythonStringAdd(S1,S2).
+_computed(O,ARGS,val(int,N)) :- _compute(O,ARGS), O=length, ARGS = (val(str,S),()), N=@pythonStringLength(S).
+_computed(O,ARGS,val(str,R)) :- _compute(O,ARGS), O=concat, ARGS = (val(str,S1),(val(str,S2),())), R=@pythonStringAdd(S1,S2).
 
 #script(python)
 

--- a/src/constraint_handler/data/symbol.lp
+++ b/src/constraint_handler/data/symbol.lp
@@ -1,14 +1,14 @@
 operator_declare(OP,(T,(T,())),bool) :- T = symbol, OP = (eq;neq).
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=eq,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 =  V2.
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=neq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 != V2.
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=leq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 <= V2.
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=lt,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 <  V2.
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=geq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 >= V2.
-computed(OP,ARGS,val(bool,true))  :- compute(OP,ARGS), OP=gt,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 >  V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=eq,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 =  V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=neq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 != V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=leq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 <= V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=lt,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 <  V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=geq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 >= V2.
+_computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=gt,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 >  V2.
 
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=eq,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 != V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=neq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 =  V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=leq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 >  V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=lt,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 >= V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=geq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 <  V2.
-computed(OP,ARGS,val(bool,false)) :- compute(OP,ARGS), OP=gt,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 <= V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=eq,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 != V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=neq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 =  V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=leq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 >  V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=lt,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 >= V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=geq, ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 <  V2.
+_computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=gt,  ARGS = (val(symbol,V1),(val(symbol,V2),())), V1 <= V2.

--- a/tests/example/multimaps.lp
+++ b/tests/example/multimaps.lp
@@ -165,11 +165,11 @@ evaluate(neq,(variable(e),(variable(d),()))).
 
 
 evaluate(multimap_fold,(val(function,myproduct),(variable(properDivisors2),(val(int,100),())))).
-computed(myproduct,ARGS,val(int,VA * VB)) :- compute(myproduct,ARGS),
+_computed(myproduct,ARGS,val(int,VA * VB)) :- _compute(myproduct,ARGS),
     ARGS = (val(int,VA),(val(int,VB),())).
 
 evaluate(multimap_fold,(val(function,snoc),(variable(properDivisors2),(val(symbol,()),())))).
-computed(snoc,ARGS,val(TN,VN)) :- compute(snoc,ARGS),
+_computed(snoc,ARGS,val(TN,VN)) :- _compute(snoc,ARGS),
     ARGS = (val(TA,VA),(val(TB,VB),())),
     TN = TB, VN = (VB, VA).
 


### PR DESCRIPTION
This moves the computed predicates to the internal side by renaming them:

compute $\to$ _compute
computeIdx $\to$ _computeIdx
computed $\to$ _computed
computedIdx $\to$ _computedIdx
stageCompute $\to$ _stageCompute