### PR TITLE
116 min operator is not implemented max is implemented already

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-02-24
+
+- `max` operator now available for `int` (previously only `float` supported `max`)
+- `min` operator now available for `int`
+- `min` operator now available for `float`
+
 ## 2026-02-23
 
 ### Functionality

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## 2026-02-24
 
-- `max` operator now available for `int` (previously only `float` supported `max`)
+- `max` operator now available for `int` (previously only `float` supported
+  `max`)
 - `min` operator now available for `int`
 - `min` operator now available for `float`
 

--- a/docs/developer/fact-format.md
+++ b/docs/developer/fact-format.md
@@ -57,7 +57,7 @@ This page describes the EBNF grammar for the fact format used by the constraint 
     | <comp-operator> | "sqrt" | "cos" | "sin" | "tan"
     | "acos" | "asin" | "atan" | "abs" | "minus"
     | "add" | "sub" | "mult" | "int_div" | "float_div" | "pow" | "floor"
-    | "max"
+    | "max" | "min"
 
 <int-operator> ::=
     | <comp-operator> | "add" | "sub" | "mult"

--- a/docs/developer/fact-format.md
+++ b/docs/developer/fact-format.md
@@ -57,6 +57,7 @@ This page describes the EBNF grammar for the fact format used by the constraint 
     | <comp-operator> | "sqrt" | "cos" | "sin" | "tan"
     | "acos" | "asin" | "atan" | "abs" | "minus"
     | "add" | "sub" | "mult" | "int_div" | "float_div" | "pow" | "floor"
+    | "max"
 
 <int-operator> ::=
     | <comp-operator> | "add" | "sub" | "mult"

--- a/docs/fact-format/fact-format.tex
+++ b/docs/fact-format/fact-format.tex
@@ -58,7 +58,7 @@
 ~\alt <comp-operator> | `sqrt' | `cos' | `sin' | `tan'
 \alt `acos' | `asin' | `atan' | `abs' | `minus'
 \alt `add' | `sub' | `mult' | `int_div' | `float_div' | `pow' | `floor'
-\alt `ceil' | `max'
+\alt `ceil' | `max' | `min'
 
 <int-operator> ::=
 ~\alt <comp-operator> | `add' | `sub' | `mult'

--- a/docs/fact-format/fact-format.tex
+++ b/docs/fact-format/fact-format.tex
@@ -58,7 +58,7 @@
 ~\alt <comp-operator> | `sqrt' | `cos' | `sin' | `tan'
 \alt `acos' | `asin' | `atan' | `abs' | `minus'
 \alt `add' | `sub' | `mult' | `int_div' | `float_div' | `pow' | `floor'
-\alt `ceil'
+\alt `ceil' | `max'
 
 <int-operator> ::=
 ~\alt <comp-operator> | `add' | `sub' | `mult'

--- a/docs/reference/base_types.md
+++ b/docs/reference/base_types.md
@@ -164,6 +164,8 @@ value(name, val(int, -7))
 | `pow` | Exponentiation | ([int], [int]) $\to$ [int] | Raises the first integer to the power of the second. |
 | `abs` | Absolute Value | ([int]) $\to$ [int] | Returns the absolute value of the integer. |
 | `minus` | Unary Minus | ([int]) $\to$ [int] | Negates the integer. |
+| `max` | Maximum | ([int], [int]) $\to$ [int] | Returns the larger of the two integers. |
+| `min` | Minimum | ([int], [int]) $\to$ [int] | Returns the smaller of the two integers. |
 | **Trigonometry** | | | |
 | `sqrt` | Square Root | ([int]) $\to$ [float] | Calculates the square root of the integer. |
 | `sin` | Sine | ([int]) $\to$ [float] | Calculates the sine of the integer. |
@@ -228,7 +230,8 @@ value(name, val(float, float("-0.001")))
 | `pow` | Exponentiation | ([float], [float]) $\to$ [float] | Raises the first value to the power of the second. |
 | `abs` | Absolute Value | ([float]) $\to$ [float] | Returns the absolute value. |
 | `minus` | Unary Minus | ([float]) $\to$ [float] | Negates the value. |
-| `max` | Maximum | ([float], [float]) $\to$ [float] | Returns the larger of the two values. |
+| `max` | Maximum | (A\[[int] \| [float]\], B\[[int] \| [float]\]) $\to$ A \| B | Returns the larger of the two values, keeping the respective type. |
+| `min` | Minimum | (A\[[int] \| [float]\], B\[[int] \| [float]\]) $\to$ A \| B | Returns the smaller of the two values, keeping the respective type. |
 | **Trigonometry** | | | |
 | `sqrt` | Square Root | ([float]) $\to$ [float] | Calculates the square root. |
 | `sin` | Sine | ([float]) $\to$ [float] | Calculates the sine. |

--- a/src/constraint_handler/data/float.lp
+++ b/src/constraint_handler/data/float.lp
@@ -1,6 +1,6 @@
 intToFloatOperator(sqrt;cos;sin;tan;acos;asin;atan).
 floatUnOperator(abs;sqrt;cos;sin;tan;acos;asin;atan;minus;floor).
-floatBinOperator(add;sub;mult;int_div;float_div;pow;leq;lt;geq;gt;max).
+floatBinOperator(add;sub;mult;int_div;float_div;pow;leq;lt;geq;gt;max;min).
 
 operator_declare_variadic(OP,T,T,2) :- T = float, OP = (add;mult).
 operator_declare(OP,(T,()),float) :- T = (int;float), intToFloatOperator(OP).

--- a/src/constraint_handler/data/int.lp
+++ b/src/constraint_handler/data/int.lp
@@ -45,6 +45,9 @@ _computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=lt,  ARGS = (val(int
 _computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=geq, ARGS = (val(int,V1),(val(int,V2),())), V1 <  V2.
 _computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=gt,  ARGS = (val(int,V1),(val(int,V2),())), V1 <= V2.
 
+_computed(OP,ARGS,val(int,V2)) :- _compute(OP,ARGS), OP=max, ARGS = (val(int,V1),(val(int,V2),())), V1 <= V2.
+_computed(OP,ARGS,val(int,V1)) :- _compute(OP,ARGS), OP=max, ARGS = (val(int,V1),(val(int,V2),())), V1 > V2.
+
 _computed(OP,ARGS,RES) :- _compute(OP,ARGS), OP=float_div, ARGS = (val(int,_),(val(int,V2),())), V2!=0,
   RES = @pythonEvalExpr(operation(OP,ARGS),(),ID),
   _main_solverIdentifier(ID).

--- a/src/constraint_handler/data/int.lp
+++ b/src/constraint_handler/data/int.lp
@@ -47,6 +47,8 @@ _computed(OP,ARGS,val(bool,false)) :- _compute(OP,ARGS), OP=gt,  ARGS = (val(int
 
 _computed(OP,ARGS,val(int,V2)) :- _compute(OP,ARGS), OP=max, ARGS = (val(int,V1),(val(int,V2),())), V1 <= V2.
 _computed(OP,ARGS,val(int,V1)) :- _compute(OP,ARGS), OP=max, ARGS = (val(int,V1),(val(int,V2),())), V1 > V2.
+_computed(OP,ARGS,val(int,V2)) :- _compute(OP,ARGS), OP=min, ARGS = (val(int,V1),(val(int,V2),())), V1 > V2.
+_computed(OP,ARGS,val(int,V1)) :- _compute(OP,ARGS), OP=min, ARGS = (val(int,V1),(val(int,V2),())), V1 <= V2.
 
 _computed(OP,ARGS,RES) :- _compute(OP,ARGS), OP=float_div, ARGS = (val(int,_),(val(int,V2),())), V2!=0,
   RES = @pythonEvalExpr(operation(OP,ARGS),(),ID),

--- a/tests/example/floats.expected.all
+++ b/tests/example/floats.expected.all
@@ -3,4 +3,5 @@ evaluated(eq,(variable(z),(operation(float_div,(variable(x),(variable(y),()))),(
 evaluated(neq,(variable(z),(operation(float_div,(variable(x),(variable(z),()))),())),val(bool,true))
 evaluated(neq,(variable(y),(operation(float_div,(variable(x),(variable(y),()))),())),val(bool,true))
 evaluated(max,(variable(x),(variable(y),())),val(float,float("5.0")))
+evaluated(min,(variable(x),(variable(y),())),val(float,float("2.5")))
 evaluated(python("int"),(variable(y),()),val(int,2))

--- a/tests/example/floats.expected.all
+++ b/tests/example/floats.expected.all
@@ -2,4 +2,5 @@ evaluated(eq,(variable(y),(operation(float_div,(variable(x),(variable(z),()))),(
 evaluated(eq,(variable(z),(operation(float_div,(variable(x),(variable(y),()))),())),val(bool,true))
 evaluated(neq,(variable(z),(operation(float_div,(variable(x),(variable(z),()))),())),val(bool,true))
 evaluated(neq,(variable(y),(operation(float_div,(variable(x),(variable(y),()))),())),val(bool,true))
+evaluated(max,(variable(x),(variable(y),())),val(float,float("5.0")))
 evaluated(python("int"),(variable(y),()),val(int,2))

--- a/tests/example/floats.lp
+++ b/tests/example/floats.lp
@@ -14,5 +14,6 @@ evaluate(neq,(variable(z),(operation(float_div,(variable(x),(variable(z),()))),(
 evaluate(neq,(variable(y),(operation(float_div,(variable(x),(variable(y),()))),()))).
 
 evaluate(max,(variable(x), (variable(y),()))).
+evaluate(min,(variable(x), (variable(y),()))).
 
 evaluate(python("int"),(variable(y),())).

--- a/tests/example/floats.lp
+++ b/tests/example/floats.lp
@@ -13,4 +13,6 @@ evaluate(eq,(variable(z),(operation(float_div,(variable(x),(variable(y),()))),()
 evaluate(neq,(variable(z),(operation(float_div,(variable(x),(variable(z),()))),()))).
 evaluate(neq,(variable(y),(operation(float_div,(variable(x),(variable(y),()))),()))).
 
+evaluate(max,(variable(x), (variable(y),()))).
+
 evaluate(python("int"),(variable(y),())).

--- a/tests/example/ints.expected.all
+++ b/tests/example/ints.expected.all
@@ -34,3 +34,4 @@ evaluated(eq,(operation(int_div,(val(int,6),(val(int,2),()))),(val(int,3),())),v
 evaluated(eq,(operation(int_div,(val(int,5),(val(int,2),()))),(val(int,2),())),val(bool,true))
 evaluated(eq,(operation(float_div,(val(int,6),(val(int,2),()))),(val(float,float("3.0")),())),val(bool,true))
 evaluated(eq,(operation(float_div,(val(int,5),(val(int,2),()))),(val(float,float("2.5")),())),val(bool,true))
+evaluated(max,(variable(two),(variable(ten),())),val(int,10))

--- a/tests/example/ints.expected.all
+++ b/tests/example/ints.expected.all
@@ -35,3 +35,4 @@ evaluated(eq,(operation(int_div,(val(int,5),(val(int,2),()))),(val(int,2),())),v
 evaluated(eq,(operation(float_div,(val(int,6),(val(int,2),()))),(val(float,float("3.0")),())),val(bool,true))
 evaluated(eq,(operation(float_div,(val(int,5),(val(int,2),()))),(val(float,float("2.5")),())),val(bool,true))
 evaluated(max,(variable(two),(variable(ten),())),val(int,10))
+evaluated(min,(variable(two),(variable(ten),())),val(int,2))

--- a/tests/example/ints.lp
+++ b/tests/example/ints.lp
@@ -66,3 +66,4 @@ evaluate(eq,(operation(int_div,(val(int,6),(val(int,2),()))),(val(int,3),()))).
 evaluate(eq,(operation(int_div,(val(int,5),(val(int,2),()))),(val(int,2),()))).
 evaluate(eq,(operation(float_div,(val(int,6),(val(int,2),()))),(val(float,float("3.0")),()))).
 evaluate(eq,(operation(float_div,(val(int,5),(val(int,2),()))),(val(float,float("2.5")),()))).
+evaluate(max,(variable(two),(variable(ten),()))).

--- a/tests/example/ints.lp
+++ b/tests/example/ints.lp
@@ -67,3 +67,4 @@ evaluate(eq,(operation(int_div,(val(int,5),(val(int,2),()))),(val(int,2),()))).
 evaluate(eq,(operation(float_div,(val(int,6),(val(int,2),()))),(val(float,float("3.0")),()))).
 evaluate(eq,(operation(float_div,(val(int,5),(val(int,2),()))),(val(float,float("2.5")),()))).
 evaluate(max,(variable(two),(variable(ten),()))).
+evaluate(min,(variable(two),(variable(ten),()))).


### PR DESCRIPTION
This adds `min` for `int` and `float`. Also, this adds `max` for `int` since previously only `float` supported `max`.