### PR TITLE
add optimization for variadic integer sum

### DIFF
--- a/src/constraint_handler/data/direct.lp
+++ b/src/constraint_handler/data/direct.lp
@@ -39,15 +39,27 @@ _se_value(E,VO) :- _direct_queryArgsValues(E,OP,ARGS), _computedIdx(E,VO).
 %%%%%%%%%%%%%%%%% _computed operators
 _direct_queryArgsValues(E,OP,ARGS) :- direct_query(E), E=operation(OP,ARGS). % decl operator
 _direct_queryArgsValues(E,OP,ARGS) :- direct_query(E), E=operation(EOP,ARGS), _se_value(EOP,val(function,OP)).
+% Some operators should not build the full evaluated argument tuple `VS` via
+% _direct_revMapAux/3 because this can create Cartesian-product grounding
+% blowups (one rule instance per combination of argument values). Such
+% operators are expected to provide results via _computedIdx/2 (or another
+% specialized route).
+%
+% Positive gate: tuple-building is allowed only when needed.
+% For `add`, enable tuple-building if at least one argument is not statically
+% typed as int. Integer-only adds can be handled cheaply via _computedIdx/2.
+_direct_doCompute(OP, ARGS) :- _direct_queryArgsValues(E, OP, ARGS), OP != add.
+_direct_doCompute(add, ARGS) :- _direct_queryArgsValues(E, add, ARGS),
+    (_, ARG) = @pythonEnumerateElements(ARGS), type_expression((), ARG, T), T != int.
 %% _direct_compArg(ARGS,IDX,ARG) :- _direct_queryArgsValues(E,OP,ARGS), (IDX,ARG)=@pythonEnumerateElements(ARGS).
 %% _direct_compMapAux(ARGS,N,()) :- _direct_queryArgsValues(E,OP,ARGS), N=@pythonListLength(ARGS).
 %% _direct_compMapAux(ARGS,IDX,K) :- _direct_compMapAux(ARGS,IDX+1,L), _direct_compArg(ARGS,IDX,ARG), _se_value(ARG,T,V), K=(val(T,V),L).
 %% _compute(OP,VS) :- _direct_queryArgsValues(E,OP,ARGS), _direct_compMapAux(ARGS,0,VS).
 %% _se_value(E,TO,VO) :- _direct_queryArgsValues(E,OP,ARGS), _direct_compMapAux(ARGS,0,VS), _computed(OP,VS,val(TO,VO)).
-_direct_revMapAux(ARGS,ES,()) :- _direct_queryArgsValues(E,OP,ARGS), ES=@pythonReversed(ARGS).
+_direct_revMapAux(ARGS,ES,()) :- _direct_queryArgsValues(E,OP,ARGS), _direct_doCompute(OP, ARGS), ES=@pythonReversed(ARGS).
 _direct_revMapAux(ARGS,ES,(V,VS)) :- _direct_revMapAux(ARGS,(E,ES),VS), _se_value(E,V).
-_compute(OP,VS) :- _direct_queryArgsValues(E,OP,ARGS), _direct_revMapAux(ARGS,(),VS).
-_se_value(E,VO) :- _direct_queryArgsValues(E,OP,ARGS), _direct_revMapAux(ARGS,(),VS), _computed(OP,VS,VO).
+_compute(OP,VS) :- _direct_queryArgsValues(E,OP,ARGS), _direct_doCompute(OP, ARGS), _direct_revMapAux(ARGS,(),VS).
+_se_value(E,VO) :- _direct_queryArgsValues(E,OP,ARGS), _direct_doCompute(OP, ARGS), _direct_revMapAux(ARGS,(),VS), _computed(OP,VS,VO).
 
 %%%%%%%%%%%%%%%%% lambda
 _lambda_aux(LAMB,ARGS,RED) :- _compute(LAMB,ARGS),

--- a/src/constraint_handler/data/int.lp
+++ b/src/constraint_handler/data/int.lp
@@ -1,12 +1,20 @@
 %%%%%%%%%%%%%%%%% add mult
 operator_declare_variadic(OP,T,T,1) :- T = int, OP = (add;mult).
-_computed(OP, ARGS, val(int, 0)) :- _compute(OP, ARGS), OP=add, ARGS = ().
-_compute(OP, TAIL) :- _compute(OP, ARGS), OP=add, ARGS = (val(int, _), TAIL).
-_computed(OP, ARGS, val(int, V1 + VTAIL)) :-
-    _compute(OP, ARGS),
-    OP=add,
-    ARGS = (val(int, V1), TAIL),
-    _computed(OP, TAIL, val(int, VTAIL)).
+
+% Direct (compile-engine) computation for addition.
+% This avoids constructing the fully-evaluated argument tuple and instead
+% aggregates over per-argument values derived by direct.lp via _computeIdx/3.
+_computedIdx(E, val(int, N)) :- _computeIdx(E, add), E = operation(add, ARGS), not _direct_doCompute(add, ARGS),
+    N = #sum { V, IDX : _computeIdx(E, IDX, val(int, V)) }.
+
+% Value-tuple computation for addition.
+% Used by encodings that explicitly create `_compute(add,ARGS)` with ARGS being
+% a tuple of `val(int,_)` terms (e.g. set_fold).
+_computed(add, ARGS, val(int, N)) :- _compute(add, ARGS),
+    0 = #sum { 1, IDX : (IDX, _) = @pythonEnumerateElements(ARGS);
+              -1, IDX : (IDX, val(int, _)) = @pythonEnumerateElements(ARGS) },
+    N = #sum { V, IDX : (IDX, val(int, V)) = @pythonEnumerateElements(ARGS) }.
+
 
 _computed(OP, ARGS, val(int, 1)) :- _compute(OP, ARGS), OP=mult, ARGS = ().
 _compute(OP, TAIL) :- _compute(OP, ARGS), OP=mult, ARGS = (val(int, _), TAIL).

--- a/tests/example/sum_aggregates.expected.any
+++ b/tests/example/sum_aggregates.expected.any
@@ -1,0 +1,1 @@
+value(sum,val(int,27))

--- a/tests/example/sum_aggregates.lp
+++ b/tests/example/sum_aggregates.lp
@@ -1,0 +1,50 @@
+% Regression: variadic integer addition over many multi-valued variables
+% Should avoid grounding Cartesian products for _compute(add,...).
+%
+% 10 integer variables with domain 1..3
+
+variable_declare(d_x1,  x1,  fromFacts).
+variable_domain(x1,  val(int, 1..3)).
+
+variable_declare(d_x2,  x2,  fromFacts).
+variable_domain(x2,  val(int, 1..3)).
+
+variable_declare(d_x3,  x3,  fromFacts).
+variable_domain(x3,  val(int, 1..3)).
+
+variable_declare(d_x4,  x4,  fromFacts).
+variable_domain(x4,  val(int, 1..3)).
+
+variable_declare(d_x5,  x5,  fromFacts).
+variable_domain(x5,  val(int, 1..3)).
+
+variable_declare(d_x6,  x6,  fromFacts).
+variable_domain(x6,  val(int, 1..3)).
+
+variable_declare(d_x7,  x7,  fromFacts).
+variable_domain(x7,  val(int, 1..3)).
+
+variable_declare(d_x8,  x8,  fromFacts).
+variable_domain(x8,  val(int, 1..3)).
+
+variable_declare(d_x9,  x9,  fromFacts).
+variable_domain(x9,  val(int, 1..3)).
+
+variable_declare(d_x10, x10, fromFacts).
+variable_domain(x10, val(int, 1..3)).
+
+% Define a helper variable "sum" as x1 + ... + x10
+variable_define(d_sum, sum,
+    operation(add, (variable(x1),
+        (variable(x2),
+        (variable(x3),
+        (variable(x4),
+        (variable(x5),
+        (variable(x6),
+        (variable(x7),
+        (variable(x8),
+        (variable(x9),
+        (variable(x10), ())))))))))))).
+
+% Ensure sum == 27
+ensure(sum_is_27, operation(eq, (variable(sum), (val(int, 27), ())))).

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -61,7 +61,7 @@ base_tests = [
     "warning_variable_undeclared_statement",
 ]
 
-compile_extra = ["preferences"]
+compile_extra = ["preferences", "sum_aggregates"]
 ground_extra = []
 propagator_extra = []
 


### PR DESCRIPTION
This is a proposal to avoid the exponential grounding blowup for integer addition by directly computing the sum in an aggregate and not relying on the exponential representation of values inside _compute.


It looks quite hacky as internals are used also in set_fold and I do not actually know what I'm doing.

I attached an example that grounds much faster with the new version. The bigger internal bike example still does not run efficiently as the number of eq comparisons is also quadratic.



@AbdallahS  maybe you can use some of the ideas here