### PR TITLE
Ks/variables fixes

### DIFF
--- a/src/constraint_handler/PropagatorConstants.py
+++ b/src/constraint_handler/PropagatorConstants.py
@@ -1,5 +1,7 @@
 import enum
 
+from constraint_handler.schemas.warning import Warning
+
 DEBUG_PRINT = False
 
 FALSE_ASSIGNMENTS = "__FALSE_ASSIGNMENTS__"
@@ -47,3 +49,6 @@ REASONING_MODE_PROGRAM = f"""
 
 class NoValueSet(Exception):
     pass
+
+
+type propagator_warning_t = list[Warning]

--- a/src/constraint_handler/PropagatorConstants.py
+++ b/src/constraint_handler/PropagatorConstants.py
@@ -1,14 +1,17 @@
 import enum
+from typing import Literal
 
 from constraint_handler.schemas.warning import Warning
 
 DEBUG_PRINT = False
 
-FALSE_ASSIGNMENTS = "__FALSE_ASSIGNMENTS__"
+DEFAULT_DECISION_LEVEL: Literal[-1] = -1
 
-ENSURE_VAR_NAME = "__ensure__"
-EXECUTION_INPUT = "execution_input"
-EXECUTION_OUTPUT = "execution_output"
+FALSE_ASSIGNMENTS: Literal["__FALSE_ASSIGNMENTS__"] = "__FALSE_ASSIGNMENTS__"
+
+ENSURE_VAR_NAME: Literal["__ensure__"] = "__ensure__"
+EXECUTION_INPUT: Literal["execution_input"] = "execution_input"
+EXECUTION_OUTPUT: Literal["execution_output"] = "execution_output"
 
 
 # enum for value_not_set, assignment_is_false, and value_is_none
@@ -35,7 +38,7 @@ class OptimizationStrength(enum.Enum):
     LENIENT = "lenient"
 
 
-REASONING_STAGE_ATOM = "__stage__"
+REASONING_STAGE_ATOM: Literal["__stage__"] = "__stage__"
 
 
 REASONING_MODE_PROGRAM = f"""

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -903,13 +903,12 @@ class Execution:
         self,
         name: str,
         func_name: clingo.Symbol,
-        stmt: statement.Stmt,
         in_vars: list[clingo.Symbol],
         out_vars: list[clingo.Symbol],
     ):
         self.name: str = name
         self.func_name: clingo.Symbol = func_name
-        self.stmt: statement.Stmt = stmt
+        self.statements: list[ExecutionStatement] = []
         self.in_vars: list[clingo.Symbol] = in_vars
         self.converted_in_vars: list[clingo.Symbol] = self.convert_vars(in_vars, input=True)
         self.out_vars: list[clingo.Symbol] = out_vars
@@ -929,6 +928,9 @@ class Execution:
         self.parents: list[VariableType] = []
 
         self.errors: list[Exception] = []
+
+    def add_statement(self, stmt: statement.Stmt, lit: int) -> None:
+        self.statements.append(ExecutionStatement(stmt, lit))
 
     def has_domain(self) -> bool:
         return True  # executions always have a domain
@@ -1002,22 +1004,37 @@ class Execution:
                 assert self.values == ValueStatus.NOT_SET
                 return EvaluationResult.NOT_CHANGED
 
+        # TODO: see if we can improve this code.
+        # There is a lot of copying of the evaluations dictionary!
         evals = {}
         for c_var, var in zip(self.converted_in_vars, self.in_vars):
             evals[var] = evaluations[c_var]
 
-        try:
-            self.errors = evaluator.evaluate_stmt(self.stmt, env, evals)
-        except solver_environment.FailIntegrityExn:
+        final_evals = dict()
+        for stmt in self.statements:
+            __evals = evals.copy()
+            result = stmt.evaluate(__evals, ctl, env)
+            if result == EvaluationResult.CONFLICT:
+                self.decision_level = ctl.assignment.decision_level
+                return EvaluationResult.CONFLICT
+            elif result == EvaluationResult.CHANGED:
+                final_evals = __evals.copy()
+
+        # check if multiple statements were run
+        # if so, take the last one run and add warning
+        # TODO: check if this is fine or better return conflict?
+        if sum([1 for stmt in self.statements if stmt.assigned]) > 1:
+            self.errors.append(
+                ValueError("Multiple statements in the same execution were run! Only the last one will be used!")
+            )
             self.decision_level = ctl.assignment.decision_level
-            return EvaluationResult.CONFLICT
 
         self.values: list[tuple[clingo.Symbol, Any]] = []
         for c_out_var, out_var in zip(self.converted_out_vars, self.out_vars):
-            if out_var not in evals:
+            if out_var not in final_evals:
                 self.values.append((c_out_var, None))
             else:
-                self.values.append((c_out_var, evals[out_var]))
+                self.values.append((c_out_var, final_evals[out_var]))
 
         return EvaluationResult.CHANGED
 
@@ -1053,17 +1070,17 @@ class Execution:
                 d[out_var] = val
 
     def __hash__(self) -> int:
-        return hash((self.func_name, self.stmt, tuple(self.in_vars), tuple(self.out_vars)))
+        return hash((self.func_name, tuple(self.statements), tuple(self.in_vars), tuple(self.out_vars)))
 
     def __repr__(self) -> str:
-        return f"Execution({self.name}, {self.func_name}, {self.stmt})"
+        return f"Execution({self.name}, {self.func_name}, {self.statements})"
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, Execution):
             return False
         return (
             self.func_name == other.func_name
-            and self.stmt == other.stmt
+            and self.statements == other.statements
             and self.in_vars == other.in_vars
             and self.out_vars == other.out_vars
         )
@@ -1114,7 +1131,7 @@ class ExecutionStatement:
         if ctl.assignment.is_false(self.literal):
             # if a particular statement is not executed,
             # then the value of this statement is just a false assignment
-            # TODO: see what makes to return here, change or not?
+            # TODO: see what to return here, change or not?
             self.value = ValueStatus.ASSIGNMENT_IS_FALSE
             self.decision_level = ctl.assignment.decision_level
             return EvaluationResult.NOT_CHANGED

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -10,6 +10,7 @@ import constraint_handler.evaluator as evaluator
 import constraint_handler.multimap as multimap
 import constraint_handler.schemas.expression as expression
 import constraint_handler.schemas.statement as statement
+import constraint_handler.schemas.warning as warning
 import constraint_handler.solver_environment as solver_environment
 from constraint_handler.PropagatorConstants import (
     DEBUG_PRINT,
@@ -18,6 +19,7 @@ from constraint_handler.PropagatorConstants import (
     FALSE_ASSIGNMENTS,
     EvaluationResult,
     ValueStatus,
+    propagator_warning_t,
 )
 
 
@@ -54,7 +56,7 @@ class VariableType(Protocol):
     def reset(self, dl: int) -> None: ...
 
     @abstractmethod
-    def get_errors(self) -> list[Exception]: ...
+    def get_errors(self) -> propagator_warning_t: ...
 
     @abstractmethod
     def vars(self) -> set[clingo.Symbol]: ...
@@ -81,7 +83,7 @@ class VariableValue:
         self.assigned: bool | None = None
         self.decision_level: int = sys.maxsize
 
-        self.errors: list[Exception] = []
+        self.errors: propagator_warning_t = []
 
     def evaluate(
         self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
@@ -114,13 +116,17 @@ class VariableValue:
                 assert self.value == ValueStatus.NOT_SET
                 return False
 
-        self.value, self.errors = evaluator.evaluate_expr(self.expr, env, evaluations)
+        self.value, errors = evaluator.evaluate_expr(self.expr, env, evaluations)
+
+        for error, msg in errors:
+            self.errors.append(warning.Warning(error, (), repr(msg)))
+
         myprint(f"{self.expr} evaluated to {self.value}")
 
         self.decision_level = min(self.decision_level, ctl.assignment.decision_level)
         return True
 
-    def get_errors(self) -> list[Exception]:
+    def get_errors(self) -> propagator_warning_t:
         return self.errors
 
     def vars(self) -> frozenset[clingo.Symbol]:
@@ -165,7 +171,7 @@ class EvaluateVariable:
         self.value: Any = ValueStatus.NOT_SET
         self.literal: int = literal
 
-        self.errors: list[Exception] = []
+        self.errors: propagator_warning_t = []
 
     def evaluate(
         self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
@@ -174,14 +180,16 @@ class EvaluateVariable:
         if not ctl.assignment.is_true(self.literal):
             return False
         myprint(f"Evaluating {self.op}({self.args})")
-        value, self.errors = evaluator.evaluate_expr(expression.Operation(self.op, self.args), env, evaluations)
+        value, errors = evaluator.evaluate_expr(expression.Operation(self.op, self.args), env, evaluations)
         self.value = value
+        for error, msg in errors:
+            self.errors.append(warning.Warning(error, (), repr(msg)))
         return True
 
     def get_value(self) -> Any:
         return self.value
 
-    def get_errors(self) -> list[Exception]:
+    def get_errors(self) -> propagator_warning_t:
         return self.errors
 
     def __eq__(self, other) -> bool:
@@ -258,7 +266,7 @@ class EnsureVariable:
     def vars(self) -> set[clingo.Symbol]:
         return set(self.expression.vars())
 
-    def get_errors(self) -> list[Exception]:
+    def get_errors(self) -> propagator_warning_t:
         return self.expression.get_errors()
 
     @property
@@ -302,6 +310,8 @@ class Variable:
         # (variable_define, variable_declare, variable_optinal)
         self.domain_literals: set[int] = set()
 
+        self.errors: propagator_warning_t = []
+
     def add_value(self, expr: expression.Expr, value_lit: int, domain_lit: int) -> None:
         self.expressions.add(VariableValue(expr, value_lit))
         self.domain_literals.add(domain_lit)
@@ -309,8 +319,8 @@ class Variable:
     def get_value(self) -> Any:
         return self.value
 
-    def get_errors(self) -> list[Exception]:
-        errors: list[Exception] = []
+    def get_errors(self) -> propagator_warning_t:
+        errors: propagator_warning_t = []
         for var_value in self.expressions:
             errors.extend(var_value.get_errors())
         return errors
@@ -371,6 +381,15 @@ class Variable:
 
         self.decision_level = ctl.assignment.decision_level
         self.value = val[0]
+        if sum(ctl.assignment.is_true(domain_lit) for domain_lit in self.domain_literals) > 1:
+            # In this instance we add a warning to say that a value was chosen out of multiple domains
+            self.errors.append(
+                warning.Warning(
+                    warning.Variable(warning.VariableWarning.multipleDeclarations),  # ty:ignore[unresolved-attribute]
+                    (self.var,),
+                    f"Multiple domain literals are true for variable {self.var}",
+                )
+            )
         return EvaluationResult.CHANGED
 
     def get_values(self) -> list[Any]:
@@ -403,7 +422,7 @@ class Variable:
         elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
             d[FALSE_ASSIGNMENTS].append(self.var)  # type: ignore
 
-        d[self.var] = value  # type: ignore
+        d[self.var] = value
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, Variable):
@@ -430,8 +449,8 @@ class SetVariableValue:
     def add_value(self, arg: expression.Expr, lit: int) -> None:
         self.values.add(VariableValue(arg, lit))
 
-    def get_errors(self) -> list[Exception]:
-        errors: list[Exception] = []
+    def get_errors(self) -> propagator_warning_t:
+        errors: propagator_warning_t = []
         for var_value in self.values:
             errors.extend(var_value.get_errors())
         return errors
@@ -515,7 +534,7 @@ class SetVariable:
 
         self.parents: list[VariableType] = []
 
-        self.errors: list[Exception] = []
+        self.errors: propagator_warning_t = []
 
     def has_domain(self) -> bool:
         return self.expressions.has_domain()
@@ -523,7 +542,7 @@ class SetVariable:
     def add_value(self, arg: expression.Expr, lit: int) -> None:
         self.expressions.add_value(arg, lit)
 
-    def get_errors(self) -> list[Exception]:
+    def get_errors(self) -> propagator_warning_t:
         return self.expressions.get_errors() + self.errors
 
     @property
@@ -568,7 +587,11 @@ class SetVariable:
             # Assignment is false, so value is set to false assignment
             self.value = ValueStatus.ASSIGNMENT_IS_FALSE
             self.decision_level = ctl.assignment.decision_level
-            self.errors.append(ValueError(f"Set declaration for {self.var} is False!"))
+            self.errors.append(
+                warning.Warning(
+                    warning.ExpressionWarning.syntaxError, (self.var,), "Set declaration is False"
+                )  # ty:ignore[unresolved-attribute]
+            )
             return EvaluationResult.CHANGED
 
         changed = self.expressions.evaluate(evaluations, ctl, env)
@@ -597,7 +620,7 @@ class SetVariable:
         elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
             d[FALSE_ASSIGNMENTS].append(self.var)  # type: ignore
 
-        d[self.var] = value  # type: ignore
+        d[self.var] = value
 
     def __eq__(self, value) -> bool:
         if not isinstance(value, SetVariable):
@@ -634,7 +657,7 @@ class DictVariable:
 
         self.parents: list[VariableType] = []
 
-        self.errors: list[Exception] = []
+        self.errors: propagator_warning_t = []
 
     def add_value(self, key: expression.Expr, expr: expression.Expr, lit: int) -> None:
         # setting lit for key to 1 since it does not have its own literal
@@ -647,8 +670,8 @@ class DictVariable:
     def has_domain(self) -> bool:
         return len(self.expressions) > 0
 
-    def get_errors(self) -> list[Exception]:
-        errors: list[Exception] = []
+    def get_errors(self) -> propagator_warning_t:
+        errors: propagator_warning_t = []
         for key, value in self.expressions.items():
             errors.extend(key.get_errors())
             errors.extend(value.get_errors())
@@ -724,7 +747,9 @@ class DictVariable:
         elif ctl.assignment.is_false(self.literal):
             self.value = ValueStatus.ASSIGNMENT_IS_FALSE
             self.decision_level = ctl.assignment.decision_level
-            self.errors.append(ValueError(f"Dict declaration for {self.var} is False!"))
+            self.errors.append(
+                warning.Warning(warning.ExpressionWarning.syntaxError, (self.var,), "Dict declaration is False")  # type: ignore[unresolved-attribute]
+            )
             return EvaluationResult.CHANGED
 
         changed = False
@@ -758,7 +783,7 @@ class DictVariable:
         elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
             d[FALSE_ASSIGNMENTS].append(self.var)  # type: ignore
 
-        d[self.var] = value  # type: ignore
+        d[self.var] = value
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, DictVariable):
@@ -808,8 +833,8 @@ class OptimizationSum:
     def get_value(self) -> int | float:
         return self.value
 
-    def get_errors(self) -> list[Exception]:
-        errors: list[Exception] = []
+    def get_errors(self) -> propagator_warning_t:
+        errors: propagator_warning_t = []
         for _, expr in self.expressions:
             errors.extend(expr.get_errors())
         return errors
@@ -889,8 +914,8 @@ class OptimizationHandler:
         for _sum in self.sums:
             _sum.reset(dl)
 
-    def get_errors(self) -> list[Exception]:
-        errors: list[Exception] = []
+    def get_errors(self) -> propagator_warning_t:
+        errors: propagator_warning_t = []
         for _sum in self.sums:
             errors.extend(_sum.get_errors())
         return errors
@@ -936,7 +961,7 @@ class Execution:
 
         self.parents: list[VariableType] = []
 
-        self.errors: list[Exception] = []
+        self.errors: propagator_warning_t = []
 
     def add_statement(self, stmt: statement.Stmt, lit: int) -> None:
         self.statements.append(ExecutionStatement(stmt, lit))
@@ -1034,7 +1059,11 @@ class Execution:
         # TODO: check if this is fine or better return conflict?
         if sum([1 for stmt in self.statements if stmt.assigned]) > 1:
             self.errors.append(
-                ValueError("Multiple statements in the same execution were run! Only the last one will be used!")
+                warning.Warning(
+                    warning.Variable(warning.VariableWarning.multipleAssignments),  # ty:ignore[unresolved-attribute]
+                    (self.func_name,),
+                    "Multiple statements in the same execution were run! Only the last one will be used!",
+                )
             )
             self.decision_level = ctl.assignment.decision_level
 
@@ -1050,7 +1079,7 @@ class Execution:
     def get_value(self) -> ValueStatus | list[tuple[clingo.Symbol, Any]]:
         return self.values
 
-    def get_errors(self) -> list[Exception]:
+    def get_errors(self) -> propagator_warning_t:
         return self.errors
 
     def add_run_literal(self, lit: int):
@@ -1100,7 +1129,7 @@ class ExecutionStatement:
         self.statement: statement.Stmt = statement
         self.literal: int = literal
         self.value: ValueStatus | list[tuple[clingo.Symbol, Any]] = ValueStatus.NOT_SET
-        self.errors: list[Exception] = []
+        self.errors: propagator_warning_t = []
         self.assigned: bool | None = None
         self.decision_level: int = sys.maxsize
 
@@ -1116,7 +1145,7 @@ class ExecutionStatement:
     def get_value(self) -> ValueStatus | list[tuple[clingo.Symbol, Any]]:
         return self.value
 
-    def get_errors(self) -> list[Exception]:
+    def get_errors(self) -> propagator_warning_t:
         return self.errors
 
     def reset(self, dl: int):
@@ -1146,7 +1175,9 @@ class ExecutionStatement:
             return EvaluationResult.NOT_CHANGED
 
         try:
-            self.errors = evaluator.evaluate_stmt(self.statement, env, evaluations)
+            errors = evaluator.evaluate_stmt(self.statement, env, evaluations)
+            for error, msg in errors:
+                self.errors.append(warning.Warning(error, (), repr(msg)))
         except solver_environment.FailIntegrityExn:
             self.decision_level = ctl.assignment.decision_level
             return EvaluationResult.CONFLICT

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -1069,6 +1069,65 @@ class Execution:
         )
 
 
+class ExecutionStatement:
+    def __init__(self, statement, literal):
+        self.statement: statement.Stmt = statement
+        self.literal: int = literal
+        self.value: ValueStatus | list[tuple[clingo.Symbol, Any]] = ValueStatus.NOT_SET
+        self.errors: list[Exception] = []
+        self.assigned: bool | None = None
+        self.decision_level: int = sys.maxsize
+
+    @property
+    def literals(self) -> set[int]:
+        if self.assigned is None:
+            return set()
+        elif self.assigned:
+            return {self.literal}
+        else:
+            return {-self.literal}
+
+    def get_value(self) -> ValueStatus | list[tuple[clingo.Symbol, Any]]:
+        return self.value
+
+    def get_errors(self) -> list[Exception]:
+        return self.errors
+
+    def reset(self, dl: int):
+        if self.decision_level >= dl:
+            self.decision_level = sys.maxsize
+            self.errors = []
+            self.value = ValueStatus.NOT_SET
+            self.assigned = None
+
+    def evaluate(
+        self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
+    ) -> EvaluationResult:
+        self.assigned = ctl.assignment.value(self.literal)
+        if self.assigned is None:
+            return EvaluationResult.NOT_CHANGED
+
+        if self.value != ValueStatus.NOT_SET:
+            # already assigned
+            return EvaluationResult.NOT_CHANGED
+
+        if ctl.assignment.is_false(self.literal):
+            # if a particular statement is not executed,
+            # then the value of this statement is just a false assignment
+            # TODO: see what makes to return here, change or not?
+            self.value = ValueStatus.ASSIGNMENT_IS_FALSE
+            self.decision_level = ctl.assignment.decision_level
+            return EvaluationResult.NOT_CHANGED
+
+        try:
+            self.errors = evaluator.evaluate_stmt(self.statement, env, evaluations)
+        except solver_environment.FailIntegrityExn:
+            self.decision_level = ctl.assignment.decision_level
+            return EvaluationResult.CONFLICT
+
+        return EvaluationResult.CHANGED
+
+
 def make_dict_from_variables(
     variables: Iterable[VariableType],
 ) -> dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]:

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -298,8 +298,13 @@ class Variable:
         self.parents: list[VariableType] = []
         self.decision_level: int = sys.maxsize
 
-    def add_value(self, expr: expression.Expr, lit: int) -> None:
-        self.expressions.add(VariableValue(expr, lit))
+        # literals for atoms that can define a domain
+        # (variable_define, variable_declare, variable_optinal)
+        self.domain_literals: set[int] = set()
+
+    def add_value(self, expr: expression.Expr, value_lit: int, domain_lit: int) -> None:
+        self.expressions.add(VariableValue(expr, value_lit))
+        self.domain_literals.add(domain_lit)
 
     def get_value(self) -> Any:
         return self.value
@@ -326,9 +331,7 @@ class Variable:
         self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> EvaluationResult:
         """
-        Evaluate the expression and return a tuple (changed, conflict).
-        changed is True if the value has changed.
-        conflict is True if there is a conflict (multiple values assigned).
+        Evaluate the expression and return an EvaluationResult.
         """
         changed = False
         for value in self.expressions:
@@ -349,11 +352,17 @@ class Variable:
                 # some values are unassigned
                 # so we cannot determine the value yet
                 val = [ValueStatus.NOT_SET]
-            else:
+
+            # if at least one domain lit is true, then a value MUST be chosen
+            elif any(ctl.assignment.is_true(domain_lit) for domain_lit in self.domain_literals):
                 # if all values are set and none are true, then it is set to false assignment
+                # And there is a conflict, as a having a domain true, means that the variable MUST have a value
                 self.decision_level = ctl.assignment.decision_level
                 self.value = ValueStatus.ASSIGNMENT_IS_FALSE
                 return EvaluationResult.CONFLICT
+            else:
+                # if no domain lit is true, then we can treat it as false
+                val = [ValueStatus.ASSIGNMENT_IS_FALSE]
 
         elif len(val) == 1:
             if val[0] == self.value:

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -108,7 +108,7 @@ class VariableValue:
             return True
 
         for var in self.vars():
-            if var not in evaluations:  # and var not in evaluations[FALSE_ASSIGNMENTS]:
+            if var not in evaluations and var not in evaluations[FALSE_ASSIGNMENTS]:
                 # can't evaluate yet
                 # value should not be set yet
                 assert self.value == ValueStatus.NOT_SET
@@ -998,7 +998,7 @@ class Execution:
             return EvaluationResult.CHANGED
 
         for var in self.converted_in_vars:
-            if var not in evaluations:  # and var not in evaluations[FALSE_ASSIGNMENTS]:
+            if var not in evaluations and var not in evaluations[FALSE_ASSIGNMENTS]:
                 # can't evaluate yet
                 # value should not be set yet
                 assert self.values == ValueStatus.NOT_SET
@@ -1148,7 +1148,7 @@ class ExecutionStatement:
 def make_dict_from_variables(
     variables: Iterable[VariableType],
 ) -> dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]:
-    result: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]] = {}
+    result: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]] = {FALSE_ASSIGNMENTS: []}  # type: ignore
     for var in variables:
         var.add_self_to_dict(result)
 

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -14,6 +14,7 @@ import constraint_handler.schemas.warning as warning
 import constraint_handler.solver_environment as solver_environment
 from constraint_handler.PropagatorConstants import (
     DEBUG_PRINT,
+    DEFAULT_DECISION_LEVEL,
     EXECUTION_INPUT,
     EXECUTION_OUTPUT,
     FALSE_ASSIGNMENTS,
@@ -81,7 +82,7 @@ class VariableValue:
 
         self.literal: int = lit
         self.assigned: bool | None = None
-        self.decision_level: int = sys.maxsize
+        self.decision_level: int = DEFAULT_DECISION_LEVEL
 
         self.errors: propagator_warning_t = []
 
@@ -123,7 +124,7 @@ class VariableValue:
 
         myprint(f"{self.expr} evaluated to {self.value}")
 
-        self.decision_level = min(self.decision_level, ctl.assignment.decision_level)
+        self.decision_level = ctl.assignment.decision_level
         return True
 
     def get_errors(self) -> propagator_warning_t:
@@ -135,7 +136,7 @@ class VariableValue:
     def reset(self, dl):
         if self.decision_level >= dl:
             self.value = ValueStatus.NOT_SET
-            self.decision_level = sys.maxsize
+            self.decision_level = DEFAULT_DECISION_LEVEL
             self.assigned = None
             self.errors = []
 
@@ -215,6 +216,7 @@ class EnsureVariable:
         self.expression: VariableValue = VariableValue(expr, literal)
 
         self.value: ValueStatus | bool = ValueStatus.NOT_SET
+        self.decision_level: int = DEFAULT_DECISION_LEVEL
 
     @property
     def var(self) -> clingo.Symbol:
@@ -249,6 +251,7 @@ class EnsureVariable:
             return EvaluationResult.NOT_CHANGED
 
         self.value = self.expression.value
+        self.decision_level = ctl.assignment.decision_level
         # assert isinstance(self.value, bool), "EnsureVariable evaluated to non-boolean value"
 
         conflict = self.value is False or self.value is None
@@ -273,14 +276,11 @@ class EnsureVariable:
     def literals(self) -> set[int]:
         return self.expression.literals
 
-    @property
-    def decision_level(self) -> int:
-        return self.expression.decision_level
-
     def reset(self, dl: int) -> None:
         self.expression.reset(dl)
         if self.decision_level >= dl:
             self.value = ValueStatus.NOT_SET
+            self.decision_level = DEFAULT_DECISION_LEVEL
 
     def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
         return
@@ -304,7 +304,7 @@ class Variable:
         self.expressions: set[VariableValue] = set()
         self.value: Any = ValueStatus.NOT_SET
         self.parents: list[VariableType] = []
-        self.decision_level: int = sys.maxsize
+        self.decision_level: int = DEFAULT_DECISION_LEVEL
 
         # literals for atoms that can define a domain
         # (variable_define, variable_declare, variable_optinal)
@@ -412,8 +412,9 @@ class Variable:
             value.reset(dl)
 
         if self.decision_level >= dl:
-            self.decision_level = sys.maxsize
+            self.decision_level = DEFAULT_DECISION_LEVEL
             self.value = ValueStatus.NOT_SET
+            self.errors = []
 
     def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
         value = self.get_value()
@@ -461,10 +462,6 @@ class SetVariableValue:
         for value in self.values:
             lits.update(value.literals)
         return lits
-
-    @property
-    def decision_level(self) -> int:
-        return min(value.decision_level for value in self.values)
 
     def get_value(self) -> ValueStatus | frozenset[Any]:
         """
@@ -530,7 +527,7 @@ class SetVariable:
 
         self.literal: int = lit  # this is the literal for the set declaration
         self.assigned: bool | None = None  # Truth value of the set declaration
-        self.decision_level: int = sys.maxsize  # decision level of the set declaration
+        self.decision_level: int = DEFAULT_DECISION_LEVEL  # decision level of the set declaration
 
         self.parents: list[VariableType] = []
 
@@ -609,7 +606,7 @@ class SetVariable:
     def reset(self, dl: int) -> None:
         self.expressions.reset(dl)
         if self.decision_level >= dl:
-            self.decision_level = sys.maxsize
+            self.decision_level = DEFAULT_DECISION_LEVEL
             self.value = ValueStatus.NOT_SET
             self.errors = []
 
@@ -653,7 +650,7 @@ class DictVariable:
 
         self.literal: int = lit
         self.assigned: bool | None = None
-        self.decision_level: int = sys.maxsize
+        self.decision_level: int = DEFAULT_DECISION_LEVEL
 
         self.parents: list[VariableType] = []
 
@@ -768,11 +765,12 @@ class DictVariable:
         return EvaluationResult.NOT_CHANGED
 
     def reset(self, dl: int) -> None:
-        for value in self.expressions.values():
+        for key, value in self.expressions.items():
+            key.reset(dl)
             value.reset(dl)
 
         if self.decision_level >= dl:
-            self.decision_level = sys.maxsize
+            self.decision_level = DEFAULT_DECISION_LEVEL
             self.value = ValueStatus.NOT_SET
             self.errors = []
 
@@ -805,7 +803,7 @@ class OptimizationSum:
         self.expressions: list[tuple[clingo.Symbol, VariableValue]] = []
         self.value: int | float = -sys.maxsize
         self.priority: int = priority
-        self.decision_level: int = sys.maxsize
+        self.decision_level: int = DEFAULT_DECISION_LEVEL
 
     def add_value(self, var: clingo.Symbol, expr: expression.Expr, lit: int) -> None:
         self.expressions.append((var, VariableValue(expr, lit)))
@@ -868,7 +866,7 @@ class OptimizationSum:
             expr.reset(dl)
 
         if self.decision_level >= dl:
-            self.decision_level = sys.maxsize
+            self.decision_level = DEFAULT_DECISION_LEVEL
             self.value = -sys.maxsize
 
     def has_unassigned(self) -> bool:
@@ -949,13 +947,10 @@ class Execution:
         self.converted_out_vars: list[clingo.Symbol] = self.convert_vars(out_vars, input=False)
 
         # this is for the execution run atom
-        # assuming the declaration atom is always a fact?
-        # otherwise, we might need a literal for that as well
-        # if there is no execution_run atom, this is always false, which means the execution is never run
         self.literal: int = -1
         self.assigned: bool | None = None
 
-        self.decision_level: int = sys.maxsize
+        self.decision_level: int = DEFAULT_DECISION_LEVEL
 
         self.values: ValueStatus | list[tuple[clingo.Symbol, Any]] = ValueStatus.NOT_SET
 
@@ -967,7 +962,7 @@ class Execution:
         self.statements.append(ExecutionStatement(stmt, lit))
 
     def has_domain(self) -> bool:
-        return True  # executions always have a domain
+        return len(self.statements) > 0
 
     def has_unassigned(self) -> bool:
         return self.values == ValueStatus.NOT_SET
@@ -984,12 +979,14 @@ class Execution:
         If the execution is not run return the negative literal.
         If the execution is unassigned return an empty set.
         """
+        lits = set()
         if self.assigned:
-            return {self.literal}
+            lits.add(self.literal)
         elif self.assigned is False:
-            return {-self.literal}
-        else:
-            return set()
+            lits.add(-self.literal)
+        for stmt in self.statements:
+            lits.update(stmt.literals)
+        return lits
 
     def convert_vars(self, vars: list[clingo.Symbol], input=True) -> list[clingo.Symbol]:
         """
@@ -1065,7 +1062,8 @@ class Execution:
                     "Multiple statements in the same execution were run! Only the last one will be used!",
                 )
             )
-            self.decision_level = ctl.assignment.decision_level
+
+        self.decision_level = ctl.assignment.decision_level
 
         self.values: list[tuple[clingo.Symbol, Any]] = []
         for c_out_var, out_var in zip(self.converted_out_vars, self.out_vars):
@@ -1089,8 +1087,11 @@ class Execution:
         return set(self.converted_in_vars)
 
     def reset(self, dl: int):
+        for stmt in self.statements:
+            stmt.reset(dl)
+
         if self.decision_level >= dl:
-            self.decision_level = sys.maxsize
+            self.decision_level = DEFAULT_DECISION_LEVEL
             self.errors = []
             self.values = ValueStatus.NOT_SET
 
@@ -1125,13 +1126,13 @@ class Execution:
 
 
 class ExecutionStatement:
-    def __init__(self, statement, literal):
-        self.statement: statement.Stmt = statement
+    def __init__(self, stmt, literal):
+        self.statement: statement.Stmt = stmt
         self.literal: int = literal
         self.value: ValueStatus | list[tuple[clingo.Symbol, Any]] = ValueStatus.NOT_SET
         self.errors: propagator_warning_t = []
         self.assigned: bool | None = None
-        self.decision_level: int = sys.maxsize
+        self.decision_level: int = DEFAULT_DECISION_LEVEL
 
     @property
     def literals(self) -> set[int]:
@@ -1150,7 +1151,7 @@ class ExecutionStatement:
 
     def reset(self, dl: int):
         if self.decision_level >= dl:
-            self.decision_level = sys.maxsize
+            self.decision_level = DEFAULT_DECISION_LEVEL
             self.errors = []
             self.value = ValueStatus.NOT_SET
             self.assigned = None

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -25,11 +25,24 @@ from constraint_handler.PropagatorConstants import (
 
 
 def myprint(*args, **kwargs):
+    """Print debug output when debugging is enabled.
+
+    This helper is a thin wrapper around ``print`` controlled by the
+    ``DEBUG_PRINT`` constant.
+
+    Args:
+        *args: Positional arguments passed to ``print``.
+        **kwargs: Keyword arguments passed to ``print``.
+    """
     if DEBUG_PRINT:
         print(*args, **kwargs)
 
 
 class VariableType(Protocol):
+    """
+    Protocol for variable types used in the propagator. Defines the required interface for variables.
+    """
+
     @property
     @abstractmethod
     def var(self) -> clingo.Symbol: ...
@@ -73,10 +86,25 @@ class VariableType(Protocol):
 
 class VariableValue:
     """
-    This class corresponds to a single expression appearing in some assingment atom
+    Represents a single expression appearing in an assignment atom.
+
+    Attributes:
+        expr: The expression to evaluate.
+        value: The current value of the expression.
+        literal: The associated literal.
+        assigned: Whether the literal is assigned.
+        decision_level: The decision level at which the value was set.
+        errors: List of warnings or errors encountered during evaluation.
     """
 
     def __init__(self, expr: expression.Expr, lit: int):
+        """
+        Initialize a VariableValue.
+
+        Args:
+            expr: Expression associated with the variable.
+            lit: The literal controlling whether this expression is evaluated.
+        """
         self.expr: expression.Expr = expr
         self.value: Any = ValueStatus.NOT_SET
 
@@ -90,9 +118,15 @@ class VariableValue:
         self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> bool:
         """
-        Evaluate the expression and return True if the value has changed.
-        We assume that a value can only be evaluated if all its variables are assigned.
-        If a value already exists(I.e, not ValueStatus.NOT_SET) then we do not evaluate again.
+        Evaluate the expression
+
+        Args:
+            evaluations: Current variable evaluations.
+            ctl: PropagateControl for checking literal assignments and decision levels.
+            env: Environment for evaluation.
+
+        Returns:
+            bool: True if the value has changed, False otherwise.
         """
         self.assigned = ctl.assignment.value(self.literal)
 
@@ -128,12 +162,30 @@ class VariableValue:
         return True
 
     def get_errors(self) -> propagator_warning_t:
+        """
+        Return warnings collected while evaluating this value.
+
+        Returns:
+            propagator_warning_t: List of warnings.
+        """
         return self.errors
 
     def vars(self) -> frozenset[clingo.Symbol]:
+        """
+        Collect variables referenced by the underlying expression.
+
+        Returns:
+            frozenset[clingo.Symbol]: Variables referenced by ``self.expr``.
+        """
         return evaluator.collectVars(self.expr)
 
     def reset(self, dl):
+        """
+        Reset based on decision level.
+
+        Args:
+            dl: Decision level threshold.
+        """
         if self.decision_level >= dl:
             self.value = ValueStatus.NOT_SET
             self.decision_level = DEFAULT_DECISION_LEVEL
@@ -142,6 +194,12 @@ class VariableValue:
 
     @property
     def literals(self) -> set[int]:
+        """
+        Return the literal that represents the current value.
+
+        Returns:
+            set[int]: A singleton set containing the signed literal if assigned; otherwise empty.
+        """
         if self.value != ValueStatus.NOT_SET:
             if self.assigned:
                 return {self.literal}
@@ -166,7 +224,26 @@ class VariableValue:
 
 
 class EvaluateVariable:
+    """
+    Represents an evaluate atom defined by an operator and arguments of the operator.
+
+    Attributes:
+        op: The operator for the expression.
+        args: List of argument expressions.
+        value: The current value of the evaluation.
+        literal: The associated literal.
+        errors: List of warnings or errors encountered during evaluation.
+    """
+
     def __init__(self, op: expression.Operator, args: list[expression.Expr], literal: int = -1):
+        """
+        Initialize an EvaluateVariable.
+
+        Args:
+            op: Operator to apply.
+            args: Operands for the operator.
+            literal: Literal controlling whether this operation is active.
+        """
         self.op: expression.Operator = op
         self.args: list[expression.Expr] = args
         self.value: Any = ValueStatus.NOT_SET
@@ -177,7 +254,17 @@ class EvaluateVariable:
     def evaluate(
         self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> bool:
-        """Evaluate the expression and return True if the value has changed."""
+        """
+        Evaluate the expression
+
+        Args:
+            evaluations: Current variable evaluations.
+            ctl: PropagateControl for checking literal assignments and decision levels.
+            env: Environment for evaluation.
+
+        Returns:
+            bool: True if the value has changed, False otherwise.
+        """
         if not ctl.assignment.is_true(self.literal):
             return False
         myprint(f"Evaluating {self.op}({self.args})")
@@ -188,9 +275,21 @@ class EvaluateVariable:
         return True
 
     def get_value(self) -> Any:
+        """
+        Return the current value of the evaluation.
+
+        Returns:
+            Any: Current value.
+        """
         return self.value
 
     def get_errors(self) -> propagator_warning_t:
+        """
+        Return warnings collected while evaluating this operation.
+
+        Returns:
+            propagator_warning_t: List of warnings.
+        """
         return self.errors
 
     def __eq__(self, other) -> bool:
@@ -209,9 +308,27 @@ class EvaluateVariable:
 
 
 class EnsureVariable:
+    """
+    Represents an 'ensure' atom, which ensures a certain expression holds.
+
+    Attributes:
+        name: Name of the ensure atom.
+        expression: The VariableValue instance being ensured.
+        value: Current value of the expression.
+        decision_level: Decision level at which the value was set.
+    """
+
     __var = clingo.Function("ensure")
 
     def __init__(self, name: str, expr: expression.Expr, literal: int):
+        """
+        Initialize an EnsureVariable.
+
+        Args:
+            name: Name of the ensure atom.
+            expr: Expression that must hold.
+            literal: Literal controlling whether the ensure atom is active.
+        """
         self.name: str = name
         self.expression: VariableValue = VariableValue(expr, literal)
 
@@ -220,13 +337,31 @@ class EnsureVariable:
 
     @property
     def var(self) -> clingo.Symbol:
+        """
+        Return the clingo symbol representing the ensure variable.
+
+        Returns:
+            clingo.Symbol: The ensure symbol.
+        """
         return self.__var
 
     @property
     def parents(self) -> list[VariableType]:
+        """
+        Return parent variables.
+
+        Returns:
+            list[VariableType]: Empty list (ensure variables have no parents).
+        """
         return []
 
     def has_domain(self) -> bool:
+        """
+        Return whether the variable has a domain.
+
+        Returns:
+            bool: Always True for ensure variables.
+        """
         return True
 
     def evaluate(
@@ -261,28 +396,71 @@ class EnsureVariable:
         return EvaluationResult.CHANGED
 
     def get_value(self) -> ValueStatus | bool:
+        """
+        Return the current value of the ensure variable.
+
+        Returns:
+            ValueStatus | bool: Current value, or NOT_SET.
+        """
         return self.value
 
     def has_unassigned(self) -> bool:
+        """
+        Check whether the ensure variable is unassigned.
+
+        Returns:
+            bool: True if the value is NOT_SET.
+        """
         return self.value == ValueStatus.NOT_SET
 
     def vars(self) -> set[clingo.Symbol]:
+        """
+        Collect variables referenced by the ensure expression.
+
+        Returns:
+            set[clingo.Symbol]: Variables referenced by the expression.
+        """
         return set(self.expression.vars())
 
     def get_errors(self) -> propagator_warning_t:
+        """
+        Return warnings collected during evaluation.
+
+        Returns:
+            propagator_warning_t: List of warnings.
+        """
         return self.expression.get_errors()
 
     @property
     def literals(self) -> set[int]:
+        """
+        Return signed literals that give the current value of the ensure variable.
+
+        Returns:
+            set[int]: Set of signed literals.
+        """
         return self.expression.literals
 
     def reset(self, dl: int) -> None:
+        """
+        Reset based on the decision level.
+
+        Args:
+            dl: Decision level threshold.
+        """
         self.expression.reset(dl)
         if self.decision_level >= dl:
             self.value = ValueStatus.NOT_SET
             self.decision_level = DEFAULT_DECISION_LEVEL
 
     def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
+        """
+        Does nothing, as ensure variables are not added to the evaluation dictionary.
+        This is here for compatibility with the VariableType protocol.
+
+        Args:
+            d: Dictionary to update.
+        """
         return
 
     def __hash__(self):
@@ -295,10 +473,31 @@ class EnsureVariable:
 class Variable:
     """
     A variable with a name and a value expression.
-    This is supposed to mirror the assign/3 atom(also propagator_assign/3) in the ASP encoding.
+
+    Class to hold the expressions assigned to a variable (via variable_define, variable_declare, etc).
+    It also evaluates them and discern the appropriate value for the variable,
+    while keeping track of the decision level and errors.
+
+
+    Attributes:
+        name: Name of the variable.
+        var: Clingo symbol for the variable.
+        expressions: Set of possible values (VariableValue).
+        value: Current value of the variable.
+        parents: Parent variables.
+        decision_level: Decision level at which the value was set.
+        domain_literals: Literals defining the domain.
+        errors: List of warnings or errors encountered during evaluation.
     """
 
     def __init__(self, name: str, var: clingo.Symbol):
+        """
+        Initialize a Variable.
+
+        Args:
+            name: Name for the variable.
+            var: Clingo symbol representing this variable.
+        """
         self.name: str = name
         self.var: clingo.Symbol = var
         self.expressions: set[VariableValue] = set()
@@ -313,28 +512,66 @@ class Variable:
         self.errors: propagator_warning_t = []
 
     def add_value(self, expr: expression.Expr, value_lit: int, domain_lit: int) -> None:
+        """
+        Add a possible value expression for this variable.
+
+        Args:
+            expr: Expression representing a candidate value.
+            value_lit: Literal for the value assignment.
+            domain_lit: Literal indicating the truth value of the domain/declaration context.
+        """
         self.expressions.add(VariableValue(expr, value_lit))
         self.domain_literals.add(domain_lit)
 
     def get_value(self) -> Any:
+        """
+        Return the current value.
+
+        Returns:
+            Any: Current value, or a ValueStatus.
+        """
         return self.value
 
     def get_errors(self) -> propagator_warning_t:
+        """
+        Return warnings collected while evaluating candidate values.
+
+        Returns:
+            propagator_warning_t: List of warnings.
+        """
         errors: propagator_warning_t = []
         for var_value in self.expressions:
             errors.extend(var_value.get_errors())
         return errors
 
     def has_unassigned(self) -> bool:
+        """
+        Check whether any candidate value is still unassigned.
+
+        Returns:
+            bool: True if any candidate value is NOT_SET.
+        """
         return any(var_value.value == ValueStatus.NOT_SET for var_value in self.expressions)
 
     def vars(self) -> set[clingo.Symbol]:
+        """
+        Collect variables referenced by all candidate value expressions.
+
+        Returns:
+            set[clingo.Symbol]: Referenced variables.
+        """
         vars = set()
         for value in self.expressions:
             vars.update(value.vars())
         return vars
 
     def has_domain(self) -> bool:
+        """
+        Return whether at least one value expression is available.
+
+        Returns:
+            bool: True if any candidate expression exists.
+        """
         return len(self.expressions) > 0
 
     def evaluate(
@@ -393,6 +630,12 @@ class Variable:
         return EvaluationResult.CHANGED
 
     def get_values(self) -> list[Any]:
+        """
+        Return all concrete values assigned to this variable.
+
+        Returns:
+            list[Any]: Values excluding NOT_SET and ASSIGNMENT_IS_FALSE.
+        """
         vals = [
             value.value
             for value in self.expressions
@@ -402,12 +645,24 @@ class Variable:
 
     @property
     def literals(self) -> set[int]:
+        """
+        Return signed literals implied by all candidate values.
+
+        Returns:
+            set[int]: Set of signed literals.
+        """
         lits = set()
         for value in self.expressions:
             lits.update(value.literals)
         return lits
 
     def reset(self, dl: int) -> None:
+        """
+        Reset based on decision level.
+
+        Args:
+            dl: Decision level threshold.
+        """
         for value in self.expressions:
             value.reset(dl)
 
@@ -417,6 +672,12 @@ class Variable:
             self.errors = []
 
     def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
+        """
+        Add this variable's value to the evaluation dictionary.
+
+        Args:
+            d: Dictionary to update.
+        """
         value = self.get_value()
         if value == ValueStatus.NOT_SET:
             return
@@ -441,16 +702,43 @@ class Variable:
 
 
 class SetVariableValue:
+    """
+    Represents a set of possible values for a set variable.
+
+    Attributes:
+        values: Set of VariableValue instances representing possible values.
+    """
+
     def __init__(self) -> None:
+        """Initialize a SetVariableValue."""
         self.values: set[VariableValue] = set()
 
     def has_domain(self) -> bool:
+        """
+        Return whether at least one value expression is present.
+
+        Returns:
+            bool: True if any value expression exists.
+        """
         return len(self.values) > 0
 
     def add_value(self, arg: expression.Expr, lit: int) -> None:
+        """
+        Add a candidate value to the set.
+
+        Args:
+            arg: Expression for a set element.
+            lit: Literal guarding the element.
+        """
         self.values.add(VariableValue(arg, lit))
 
     def get_errors(self) -> propagator_warning_t:
+        """
+        Return warnings collected while evaluating set elements.
+
+        Returns:
+            propagator_warning_t: List of warnings.
+        """
         errors: propagator_warning_t = []
         for var_value in self.values:
             errors.extend(var_value.get_errors())
@@ -458,6 +746,12 @@ class SetVariableValue:
 
     @property
     def literals(self) -> set[int]:
+        """
+        Return signed literals implied by currently evaluated set elements.
+
+        Returns:
+            set[int]: Set of signed literals.
+        """
         lits = set()
         for value in self.values:
             lits.update(value.literals)
@@ -474,9 +768,21 @@ class SetVariableValue:
         return frozenset(arg.value for arg in self.values if arg.value != ValueStatus.ASSIGNMENT_IS_FALSE)
 
     def has_unassigned(self) -> bool:
+        """
+        Check whether any element value is still unassigned.
+
+        Returns:
+            bool: True if any element is NOT_SET.
+        """
         return any(arg.value == ValueStatus.NOT_SET for arg in self.values)
 
     def vars(self) -> set[clingo.Symbol]:
+        """
+        Collect variables referenced by all set element expressions.
+
+        Returns:
+            set[clingo.Symbol]: Referenced variables.
+        """
         vars = set()
         for arg in self.values:
             vars.update(arg.vars())
@@ -493,6 +799,12 @@ class SetVariableValue:
         return changed
 
     def reset(self, dl: int) -> None:
+        """
+        Reset all element values based on decision level.
+
+        Args:
+            dl: Decision level threshold.
+        """
         for arg in self.values:
             arg.reset(dl)
 
@@ -514,11 +826,31 @@ class SetVariableValue:
 class SetVariable:
     """
     A set variable with a name and a set of value expressions.
+
     This is supposed to mirror the set_declare/2 and set_assign/3 atom in the ASP encoding.
-    set_declare is this class, while each set_assign adds a value to the set(which uses the SetVariableValue class).
+    set_declare is this class, while each set_assign adds a possible value to the set.
+
+    Attributes:
+        name: Name of the set variable.
+        var: Clingo symbol for the variable.
+        expressions: SetVariableValue instance holding possible values.
+        value: Current value of the set variable.
+        literal: Literal for the set declaration.
+        assigned: Truth value of the set declaration.
+        decision_level: Decision level of the set declaration.
+        parents: Parent variables.
+        errors: List of warnings or errors encountered during evaluation.
     """
 
     def __init__(self, name: str, var: clingo.Symbol, lit: int):
+        """
+        Initialize a SetVariable.
+
+        Args:
+            name: Name of the set variable.
+            var: Clingo symbol identifying the variable.
+            lit: Literal for the set declaration.
+        """
         self.name: str = name
         self.var: clingo.Symbol = var
         self.expressions: SetVariableValue = SetVariableValue()
@@ -534,16 +866,44 @@ class SetVariable:
         self.errors: propagator_warning_t = []
 
     def has_domain(self) -> bool:
+        """
+        Check whether the set has a domain.
+
+        Returns:
+            bool: True if at least one value can be assigned.
+        """
         return self.expressions.has_domain()
 
     def add_value(self, arg: expression.Expr, lit: int) -> None:
+        """
+        Add a potential value expression to the set.
+
+        Args:
+            arg: Expression representing one possible set element.
+            lit: Literal for the corresponding `set_assign/3` atom.
+        """
         self.expressions.add_value(arg, lit)
 
     def get_errors(self) -> propagator_warning_t:
+        """
+        Return warnings/errors collected during evaluation.
+
+        Returns:
+            propagator_warning_t: Warnings and errors for this set and its elements.
+        """
         return self.expressions.get_errors() + self.errors
 
     @property
     def literals(self) -> set[int]:
+        """
+        Return literals relevant for this variable's current state.
+
+        Includes literals from all element assignments and, if assigned,
+        the set declaration literal.
+
+        Returns:
+            set[int]: Set of literals.
+        """
         lits = self.expressions.literals
         if self.assigned is not None:
             if self.assigned:
@@ -560,9 +920,21 @@ class SetVariable:
         return self.value
 
     def has_unassigned(self) -> bool:
+        """
+        Check whether any element expression is still unassigned.
+
+        Returns:
+            bool: True if at least one element is unassigned.
+        """
         return self.expressions.has_unassigned()
 
     def vars(self) -> set[clingo.Symbol]:
+        """
+        Collect all variables referenced by this set.
+
+        Returns:
+            set[clingo.Symbol]: Variables used in element expressions.
+        """
         return self.expressions.vars()
 
     def evaluate(
@@ -604,6 +976,12 @@ class SetVariable:
         return EvaluationResult.NOT_CHANGED
 
     def reset(self, dl: int) -> None:
+        """
+        Reset based on decision level.
+
+        Args:
+            dl: Decision level threshold.
+        """
         self.expressions.reset(dl)
         if self.decision_level >= dl:
             self.decision_level = DEFAULT_DECISION_LEVEL
@@ -611,6 +989,12 @@ class SetVariable:
             self.errors = []
 
     def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
+        """
+        Add this variable's value into an output dictionary.
+
+        Args:
+            d: Dictionary to update.
+        """
         value = self.get_value()
         if value == ValueStatus.NOT_SET:
             return
@@ -637,11 +1021,31 @@ class SetVariable:
 class DictVariable:
     """
     A dict variable with a name and a set of key-value expressions.
+
     This is supposed to mirror the multimap_declare/2 and multimap_assign/4 atom in the ASP encoding.
-    multimap_declare is this class, while each multimap_assign adds a key-value pair to the dict(which uses the SetVariableValue class).
+    multimap_declare is this class, while each multimap_assign adds a possible key-value pair to the dict.
+
+    Attributes:
+        name: Name of the dict variable.
+        var: Clingo symbol for the variable.
+        expressions: Dictionary mapping keys to SetVariableValue instances.
+        value: Current value of the dict variable.
+        literal: Literal for the dict declaration.
+        assigned: Truth value of the dict declaration.
+        decision_level: Decision level of the current value.
+        parents: Parent variables.
+        errors: List of warnings or errors encountered during evaluation.
     """
 
     def __init__(self, name: str, var: clingo.Symbol, lit: int):
+        """
+        Initialize a DictVariable.
+
+        Args:
+            name: Name of the dict variable.
+            var: Clingo symbol identifying the variable.
+            lit: Literal for the dict declaration.
+        """
         self.name: str = name
         self.var: clingo.Symbol = var
         self.expressions: dict[VariableValue, SetVariableValue] = multimap.HashableDict()
@@ -657,6 +1061,14 @@ class DictVariable:
         self.errors: propagator_warning_t = []
 
     def add_value(self, key: expression.Expr, expr: expression.Expr, lit: int) -> None:
+        """
+        Add a key-value pair to the dict variable.
+
+        Args:
+            key: Expression for the key.
+            expr: Expression for the value.
+            lit: Literal for assignment.
+        """
         # setting lit for key to 1 since it does not have its own literal
         # the literal is bound for the value!
         key_val = VariableValue(key, 1)
@@ -665,9 +1077,21 @@ class DictVariable:
         self.expressions[key_val].add_value(expr, lit)
 
     def has_domain(self) -> bool:
+        """
+        Check if the dict variable has a domain (any key-value pairs).
+
+        Returns:
+            bool: True if there are key-value pairs, False otherwise.
+        """
         return len(self.expressions) > 0
 
     def get_errors(self) -> propagator_warning_t:
+        """
+        Get all errors from the dict variable and its key-value pairs.
+
+        Returns:
+            propagator_warning_t: List of warnings or errors.
+        """
         errors: propagator_warning_t = []
         for key, value in self.expressions.items():
             errors.extend(key.get_errors())
@@ -676,6 +1100,15 @@ class DictVariable:
 
     @property
     def literals(self) -> set[int]:
+        """
+        Return literals relevant for this variable's current state.
+
+        Includes literals from all key/value expressions and, if assigned,
+        the dict declaration literal.
+
+        Returns:
+            set[int]: Set of literals.
+        """
         lits = set()
         for key, value in self.expressions.items():
             lits.update(value.literals)
@@ -690,6 +1123,12 @@ class DictVariable:
         return lits
 
     def get_value(self) -> ValueStatus | dict[clingo.Symbol, Any]:
+        """
+        Get the current value of the dict variable.
+
+        Returns:
+            ValueStatus | dict[clingo.Symbol, Any]: Current dict value or NOT_SET.
+        """
         return self.value
 
     def discern_value(self) -> ValueStatus | dict[clingo.Symbol, Any]:
@@ -715,9 +1154,21 @@ class DictVariable:
         return result
 
     def has_unassigned(self) -> bool:
-        return any(value.has_unassigned() for value in self.expressions.values())
+        """
+        Check whether any key/value expression is still unassigned.
+
+        Returns:
+            bool: True if any key/value expression is unassigned.
+        """
+        return any(key.assigned is None or value.has_unassigned() for key, value in self.expressions.items())
 
     def vars(self) -> set[clingo.Symbol]:
+        """
+        Collect all variables referenced by this dict.
+
+        Returns:
+            set[clingo.Symbol]: Variables used in key/value expressions.
+        """
         vars = set()
         for key, value in self.expressions.items():
             vars.update(value.vars())
@@ -765,6 +1216,12 @@ class DictVariable:
         return EvaluationResult.NOT_CHANGED
 
     def reset(self, dl: int) -> None:
+        """
+        Reset based on the decision level.
+
+        Args:
+            dl: Decision level threshold.
+        """
         for key, value in self.expressions.items():
             key.reset(dl)
             value.reset(dl)
@@ -775,6 +1232,12 @@ class DictVariable:
             self.errors = []
 
     def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
+        """
+        Add this variable's value into the given dictionary.
+
+        Args:
+            d: Dictionary to update.
+        """
         value = self.get_value()
         if value == ValueStatus.NOT_SET:
             return
@@ -799,23 +1262,61 @@ class DictVariable:
 
 
 class OptimizationSum:
+    """
+    Represents a sum for optimization purposes, holding expressions and their priorities.
+
+    Attributes:
+        expressions: List of (clingo.Symbol, VariableValue) pairs.
+                    The symbol is the variable associated with the expresssion.
+                    The value of the expression is what is used in the sum.
+        value: The current sum value.
+        priority: Priority of the optimization sum.
+        decision_level: Decision level at which the value was set.
+    """
+
     def __init__(self, priority: int = 0) -> None:
+        """
+        Initialize an OptimizationSum.
+
+        Args:
+            priority: Priority of the optimization sum.
+        """
         self.expressions: list[tuple[clingo.Symbol, VariableValue]] = []
         self.value: int | float = -sys.maxsize
         self.priority: int = priority
         self.decision_level: int = DEFAULT_DECISION_LEVEL
 
     def add_value(self, var: clingo.Symbol, expr: expression.Expr, lit: int) -> None:
+        """
+        Add a value to the optimization sum.
+
+        Args:
+            var: Clingo symbol for the variable.
+            expr: Expression to evaluate.
+            lit: Associated literal.
+        """
         self.expressions.append((var, VariableValue(expr, lit)))
 
     @property
     def literals(self) -> set[int]:
+        """
+        Get all literals associated with the optimization sum that gave it its current value.
+
+        Returns:
+            set[int]: Set of literals.
+        """
         lits = set()
         for var, expr in self.expressions:
             lits.update(expr.literals)
         return lits
 
     def discern_value(self) -> int | float:
+        """
+        Compute the sum of all assigned values in the optimization sum.
+
+        Returns:
+            int | float: The sum of all assigned values.
+        """
         vals = set()
         for var, expr in self.expressions:
             myprint(f"Summing {expr} with value {expr.value}")
@@ -829,9 +1330,21 @@ class OptimizationSum:
         return sum(value for var, value in vals)
 
     def get_value(self) -> int | float:
+        """
+        Get the current value of the optimization sum.
+
+        Returns:
+            int | float: The sum value.
+        """
         return self.value
 
     def get_errors(self) -> propagator_warning_t:
+        """
+        Get all errors from the evaluation of the optimization sum.
+
+        Returns:
+            propagator_warning_t: List of warnings or errors.
+        """
         errors: propagator_warning_t = []
         for _, expr in self.expressions:
             errors.extend(expr.get_errors())
@@ -840,7 +1353,17 @@ class OptimizationSum:
     def evaluate(
         self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> bool:
-        """Evaluate the expression and return True if the value has changed."""
+        """
+        Evaluate the optimization sum and return True if the value has changed.
+
+        Args:
+            evaluations: Current variable evaluations.
+            ctl: Clingo propagate control.
+            env: Evaluation environment.
+
+        Returns:
+            bool: True if the value has changed, False otherwise.
+        """
         changed = False
 
         for var, expr in self.expressions:
@@ -856,12 +1379,24 @@ class OptimizationSum:
         return False
 
     def vars(self) -> set[clingo.Symbol]:
+        """
+        Collect all variables used in the optimization sum.
+
+        Returns:
+            set[clingo.Symbol]: Set of variables in the optimization sum.
+        """
         vars = set()
         for var, expr in self.expressions:
             vars.update(expr.vars())
         return vars
 
     def reset(self, dl: int):
+        """
+        Reset the optimization sum if the decision level is greater than or equal to dl.
+
+        Args:
+            dl: Decision level threshold.
+        """
         for var, expr in self.expressions:
             expr.reset(dl)
 
@@ -870,6 +1405,12 @@ class OptimizationSum:
             self.value = -sys.maxsize
 
     def has_unassigned(self) -> bool:
+        """
+        Check if any value in the optimization sum is unassigned.
+
+        Returns:
+            bool: True if any value is unassigned, False otherwise.
+        """
         return any(expr.value == ValueStatus.NOT_SET for var, expr in self.expressions)
 
     def __repr__(self) -> str:
@@ -877,10 +1418,31 @@ class OptimizationSum:
 
 
 class OptimizationHandler:
+    """
+    Handles multiple optimization sums, each with a priority.
+
+    Attributes:
+        sums: List of OptimizationSum instances.
+              Note that this is a list and not a dict.
+              OptimizationSums are ordered by priority, with higher priority sums coming first.
+    """
+
     def __init__(self):
+        """
+        Initialize an OptimizationHandler.
+        """
         self.sums: list[OptimizationSum] = []
 
     def add_value(self, var: clingo.Symbol, expr: expression.Expr, lit: int, priority: int = 0) -> None:
+        """
+        Add a value to the appropriate optimization sum by priority.
+
+        Args:
+            var: Clingo symbol for the variable.
+            expr: Expression to evaluate.
+            lit: Associated literal.
+            priority: Priority of the optimization sum.
+        """
         for _sum in self.sums:
             if _sum.priority == priority:
                 _sum.add_value(var, expr, lit)
@@ -892,45 +1454,109 @@ class OptimizationHandler:
         self.sums.sort(key=lambda x: x.priority, reverse=True)  # higher priority first
 
     def get_sum_count(self) -> int:
+        """
+        Get the number of optimization sums.
+
+        Returns:
+            int: Number of optimization sums.
+        """
         return len(self.sums)
 
     def evaluate(
         self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> bool:
+        """
+        Evaluate all optimization sums and return True if any value has changed.
+
+        Args:
+            evaluations: Current variable evaluations.
+            ctl: Clingo propagate control.
+            env: Evaluation environment.
+
+        Returns:
+            bool: True if any value has changed, False otherwise.
+        """
         changed = False
         for _sum in self.sums:
             changed |= _sum.evaluate(evaluations, ctl, env)
         return changed
 
     def vars(self) -> set[clingo.Symbol]:
+        """
+        Collect all variables used in all optimization sums.
+
+        Returns:
+            set[clingo.Symbol]: Set of variables in all optimization sums.
+        """
         vars = set()
         for _sum in self.sums:
             vars.update(_sum.vars())
         return vars
 
     def reset(self, dl: int):
+        """
+        Reset all optimization sums.
+
+        Args:
+            dl: Decision level threshold.
+        """
         for _sum in self.sums:
             _sum.reset(dl)
 
     def get_errors(self) -> propagator_warning_t:
+        """
+        Get all errors from all optimization sums.
+
+        Returns:
+            propagator_warning_t: List of warnings or errors.
+        """
         errors: propagator_warning_t = []
         for _sum in self.sums:
             errors.extend(_sum.get_errors())
         return errors
 
     def get_value(self) -> list[int | float]:
+        """
+        Get the values of all optimization sums ordered by priority.
+
+        Returns:
+            list[int | float]: List of current sum values.
+        """
         return [_sum.get_value() for _sum in self.sums]
 
     def has_unassigned(self, position: int) -> bool:
         """
-        Note that position is the index of the optimization sum in the sums list, which is sorted by priority.
-        So position 0 is the highest priority sum, position 1 is the second highest priority sum, and so on.
-        It is NOT the priority!
+        Check if the optimization sum at the given position has unassigned values.
+
+        Args:
+            position: Index of the optimization sum (sorted by priority).
+
+        Returns:
+            bool: True if there are unassigned values, False otherwise.
         """
         return self.sums[position].has_unassigned()
 
 
 class Execution:
+    """
+    Represents an execution block, holding statements and input/output variables.
+
+    Attributes:
+        name: Name of the execution.
+        func_name: Clingo symbol for the function name.
+        statements: List of ExecutionStatement instances.
+        in_vars: List of input variable symbols.
+        converted_in_vars: List of converted input variable symbols.
+        out_vars: List of output variable symbols.
+        converted_out_vars: List of converted output variable symbols.
+        literal: Literal for the execution run atom.
+        assigned: Truth value of the execution run atom.
+        decision_level: Decision level of the execution.
+        values: Current values of the execution outputs.
+        parents: Parent variables.
+        errors: List of warnings or errors encountered during evaluation.
+    """
+
     def __init__(
         self,
         name: str,
@@ -938,6 +1564,15 @@ class Execution:
         in_vars: list[clingo.Symbol],
         out_vars: list[clingo.Symbol],
     ):
+        """
+        Initialize an Execution.
+
+        Args:
+            name: Name of the execution.
+            func_name: Clingo symbol for the function name.
+            in_vars: List of input variable symbols.
+            out_vars: List of output variable symbols.
+        """
         self.name: str = name
         self.func_name: clingo.Symbol = func_name
         self.statements: list[ExecutionStatement] = []
@@ -959,16 +1594,43 @@ class Execution:
         self.errors: propagator_warning_t = []
 
     def add_statement(self, stmt: statement.Stmt, lit: int) -> None:
+        """
+        Add a statement to the execution.
+
+        Args:
+            stmt: Statement to add.
+            lit: Associated literal.
+        """
         self.statements.append(ExecutionStatement(stmt, lit))
 
     def has_domain(self) -> bool:
+        """
+        Check if the execution has any statements (domain).
+
+        Returns:
+            bool: True if there are statements, False otherwise.
+        """
         return len(self.statements) > 0
 
     def has_unassigned(self) -> bool:
+        """
+        Check if the execution has a value assigned to its outputs.
+
+        Returns:
+            bool: True if unassigned, False otherwise.
+        """
         return self.values == ValueStatus.NOT_SET
 
     @property
     def var(self) -> clingo.Symbol:
+        """
+        Get the function name symbol for the execution.
+        Note that the variables used inside the execution are local to the execution,
+        hence, they do not get returned here.
+
+        Returns:
+            clingo.Symbol: Function name symbol.
+        """
         return self.func_name
 
     @property
@@ -978,6 +1640,10 @@ class Execution:
         If the execution is run return the positive literal.
         If the execution is not run return the negative literal.
         If the execution is unassigned return an empty set.
+        Also add the literals of the statements in the execution.
+
+        Returns:
+            set[int]: Set of literals.
         """
         lits = set()
         if self.assigned:
@@ -990,7 +1656,14 @@ class Execution:
 
     def convert_vars(self, vars: list[clingo.Symbol], input=True) -> list[clingo.Symbol]:
         """
-        Convert the name of the variable from e.g. x to execution_input(fname, x)
+        Convert the name of the variable from e.g. x to execution_input(fname, x) or execution_output(fname, x).
+
+        Args:
+            vars: List of variable symbols.
+            input: If True, convert to input; otherwise, output.
+
+        Returns:
+            list[clingo.Symbol]: Converted variable symbols.
         """
         converted: list[clingo.Symbol] = []
         for var in vars:
@@ -998,6 +1671,16 @@ class Execution:
         return converted
 
     def convert_var(self, var: clingo.Symbol | str, input=True) -> clingo.Symbol:
+        """
+        Convert a variable to an execution input or output symbol.
+
+        Args:
+            var: Variable symbol or string.
+            input: If True, convert to input; otherwise, output.
+
+        Returns:
+            clingo.Symbol: Converted symbol.
+        """
         exec_name: str = EXECUTION_INPUT if input else EXECUTION_OUTPUT
 
         if isinstance(var, clingo.Symbol):
@@ -1011,7 +1694,17 @@ class Execution:
     def evaluate(
         self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> EvaluationResult:
-        """Evaluate the execution and return True if the value has changed."""
+        """
+        Evaluate the execution and return an EvaluationResult.
+
+        Args:
+            evaluations: Current variable evaluations.
+            ctl: Clingo propagate control.
+            env: Evaluation environment.
+
+        Returns:
+            EvaluationResult: Result of the evaluation (CHANGED, NOT_CHANGED, or CONFLICT).
+        """
         self.assigned = ctl.assignment.value(self.literal)
         if self.assigned is None:
             return EvaluationResult.NOT_CHANGED
@@ -1075,21 +1768,51 @@ class Execution:
         return EvaluationResult.CHANGED
 
     def get_value(self) -> ValueStatus | list[tuple[clingo.Symbol, Any]]:
+        """
+        Get the current values of the execution outputs.
+
+        Returns:
+            ValueStatus | list[tuple[clingo.Symbol, Any]]: Output values or NOT_SET.
+        """
         return self.values
 
     def get_errors(self) -> propagator_warning_t:
+        """
+        Get all errors from the execution and its statements.
+
+        Returns:
+            propagator_warning_t: List of warnings or errors.
+        """
         errors = self.errors.copy()
         for stmt in self.statements:
             errors.extend(stmt.get_errors())
         return errors
 
     def add_run_literal(self, lit: int):
+        """
+        Set the literal for the execution run atom.
+
+        Args:
+            lit: Literal value.
+        """
         self.literal = lit
 
     def vars(self) -> set[clingo.Symbol]:
+        """
+        Collect all input variables for the execution.
+
+        Returns:
+            set[clingo.Symbol]: Set of input variable symbols.
+        """
         return set(self.converted_in_vars)
 
     def reset(self, dl: int):
+        """
+        Reset the execution and its statements based on the decision level.
+
+        Args:
+            dl: Decision level threshold.
+        """
         for stmt in self.statements:
             stmt.reset(dl)
 
@@ -1099,6 +1822,12 @@ class Execution:
             self.values = ValueStatus.NOT_SET
 
     def add_self_to_dict(self, d: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]) -> None:
+        """
+        Add the execution's output values to the provided dictionary.
+
+        Args:
+            d: Dictionary to update.
+        """
         value = self.get_value()
 
         if value == ValueStatus.NOT_SET:
@@ -1129,7 +1858,26 @@ class Execution:
 
 
 class ExecutionStatement:
+    """
+    Represents a possible statement that an execution can run.
+
+    Attributes:
+        statement: The statement to execute.
+        literal: Associated literal.
+        value: Current value of the statement.
+        errors: List of warnings or errors encountered during evaluation.
+        assigned: Truth value of the statement.
+        decision_level: Decision level at which the value was set.
+    """
+
     def __init__(self, stmt, literal):
+        """
+        Initialize an ExecutionStatement.
+
+        Args:
+            stmt: Statement to execute.
+            literal: Associated literal.
+        """
         self.statement: statement.Stmt = stmt
         self.literal: int = literal
         self.value: ValueStatus | list[tuple[clingo.Symbol, Any]] = ValueStatus.NOT_SET
@@ -1139,6 +1887,12 @@ class ExecutionStatement:
 
     @property
     def literals(self) -> set[int]:
+        """
+        Get the literal(s) associated with this statement.
+
+        Returns:
+            set[int]: Set of literals.
+        """
         if self.assigned is None:
             return set()
         elif self.assigned:
@@ -1147,12 +1901,30 @@ class ExecutionStatement:
             return {-self.literal}
 
     def get_value(self) -> ValueStatus | list[tuple[clingo.Symbol, Any]]:
+        """
+        Get the current value of the statement.
+
+        Returns:
+            ValueStatus | list[tuple[clingo.Symbol, Any]]: Value or NOT_SET.
+        """
         return self.value
 
     def get_errors(self) -> propagator_warning_t:
+        """
+        Get all errors from the statement evaluation.
+
+        Returns:
+            propagator_warning_t: List of warnings or errors.
+        """
         return self.errors
 
     def reset(self, dl: int):
+        """
+        Reset the statement based on the decision level.
+
+        Args:
+            dl: Decision level threshold.
+        """
         if self.decision_level >= dl:
             self.decision_level = DEFAULT_DECISION_LEVEL
             self.errors = []
@@ -1162,6 +1934,17 @@ class ExecutionStatement:
     def evaluate(
         self, evaluations: dict[clingo.Symbol, Any], ctl: clingo.PropagateControl, env: dict[Any, Any]
     ) -> EvaluationResult:
+        """
+        Evaluate the execution statements and return an EvaluationResult.
+
+        Args:
+            evaluations: Current variable evaluations.
+            ctl: Clingo propagate control.
+            env: Evaluation environment.
+
+        Returns:
+            EvaluationResult: Result of the evaluation (CHANGED, NOT_CHANGED, or CONFLICT).
+        """
         self.assigned = ctl.assignment.value(self.literal)
         if self.assigned is None:
             return EvaluationResult.NOT_CHANGED
@@ -1193,6 +1976,17 @@ class ExecutionStatement:
 def make_dict_from_variables(
     variables: Iterable[VariableType],
 ) -> dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]:
+    """Build a plain Python dictionary from a collection of variables.
+
+    The resulting dictionary maps each variable symbol to its evaluated value.
+    Variables that are assigned false are listed under the `FALSE_ASSIGNMENTS` key.
+
+    Args:
+        variables: Iterable of variables to export. Variables must implement the `add_self_to_dict` method!
+
+    Returns:
+        dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]]: Dictionary of variable values.
+    """
     result: dict[clingo.Symbol, Any | set[Any] | dict[Any, Any]] = {FALSE_ASSIGNMENTS: []}  # type: ignore
     for var in variables:
         var.add_self_to_dict(result)

--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -1078,7 +1078,10 @@ class Execution:
         return self.values
 
     def get_errors(self) -> propagator_warning_t:
-        return self.errors
+        errors = self.errors.copy()
+        for stmt in self.statements:
+            errors.extend(stmt.get_errors())
+        return errors
 
     def add_run_literal(self, lit: int):
         self.literal = lit
@@ -1177,10 +1180,11 @@ class ExecutionStatement:
 
         try:
             errors = evaluator.evaluate_stmt(self.statement, env, evaluations)
+            self.decision_level: int = ctl.assignment.decision_level
             for error, msg in errors:
                 self.errors.append(warning.Warning(error, (), repr(msg)))
         except solver_environment.FailIntegrityExn:
-            self.decision_level = ctl.assignment.decision_level
+            self.decision_level: int = ctl.assignment.decision_level
             return EvaluationResult.CONFLICT
 
         return EvaluationResult.CHANGED

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -732,15 +732,27 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         """
         declares = myClorm.findInPropagateInit(ctl, atom.Propagator_execution_declare)
         for (name, symbol_var, stmt, in_v, out_v), literal in declares.items():
-            variable = Execution(name, symbol_var, stmt, in_v, out_v)
+            if symbol_var in self.symbol2var:
+                variable = cast(Execution, self.symbol2var[symbol_var])
+            else:
+                variable = Execution(name, symbol_var, in_v, out_v)
+                self.symbol2var[symbol_var] = variable
 
-            if literal != 1:
-                self.errors.append((warning.Propagator(), SyntaxError(f"Execution {name} declaration is not a fact!")))
-
-            self.symbol2var[symbol_var] = variable
+            variable.add_statement(stmt, literal)
+            if literal not in self.literal2var:
+                self.literal2var[literal] = []
+            self.literal2var[literal].append(variable)
 
         exec_runs = myClorm.findInPropagateInit(ctl, atom.Propagator_execution_run)
         for (name, symbol_var), literal in exec_runs.items():
+            if symbol_var not in self.symbol2var:
+                self.errors.append(
+                    (
+                        warning.Variable(warning.VariableWarning.undeclared),
+                        f"Execution variable '{symbol_var}' run exists but variable not declared!",
+                    )
+                )
+                continue
             execvar: Execution = cast(Execution, self.symbol2var[symbol_var])
             execvar.add_run_literal(literal)
             if literal not in self.literal2var:

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -435,7 +435,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         It returns True if the variable's value changed, False if it did not change,
         and None if there was a conflict.
         """
-        eval_result = var.evaluate(make_dict_from_variables(self.symbol2var.values()), ctl, self.environment)
+        eval_result: EvaluationResult = var.evaluate(
+            make_dict_from_variables(self.symbol2var.values()), ctl, self.environment
+        )
         myprint(f"Variable {var} evaluation result: {eval_result}")
 
         if eval_result == EvaluationResult.CONFLICT:
@@ -517,11 +519,15 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 literal_true = ctl.add_literal(freeze=True)
                 literal_false = ctl.add_literal(freeze=True)
                 variable.add_value(
-                    expression.Val(expression.BaseType.bool, True), literal_true, __literal
-                )  # ty:ignore[unresolved-attribute]
+                    expression.Val(expression.BaseType.bool, True),  # ty:ignore[unresolved-attribute]
+                    literal_true,
+                    __literal,
+                )
                 variable.add_value(
-                    expression.Val(expression.BaseType.bool, False), literal_false, __literal
-                )  # ty:ignore[unresolved-attribute]
+                    expression.Val(expression.BaseType.bool, False),  # ty:ignore[unresolved-attribute]
+                    literal_false,
+                    __literal,
+                )
                 ctl.add_watch(literal_true)
                 ctl.add_watch(-literal_true)
                 ctl.add_watch(literal_false)
@@ -677,7 +683,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
     def get_evaluate(self, ctl: clingo.PropagateInit):
         """
         This method initializes the variables from the ASP encoding.
-        It reads the propagator_assign atoms and creates Variable instances.
+        It reads the evaluate atoms and creates EvaluateVariable instances.
         """
 
         for (op, args), literal in myClorm.findInPropagateInit(ctl, atom.Propagator_evaluate).items():
@@ -804,6 +810,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             if literal not in self.literal2var:
                 self.literal2var[literal] = []
             self.literal2var[literal].append(variable)
+
+            ctl.add_watch(literal)
+            ctl.add_watch(-literal)
 
         exec_runs = myClorm.findInPropagateInit(ctl, atom.Propagator_execution_run)
         for (name, symbol_var), literal in exec_runs.items():

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -494,44 +494,54 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         var_defines = myClorm.findInPropagateInit(ctl, atom.Propagator_variable_define)
         var_domains = myClorm.findInPropagateInit(ctl, atom.Propagator_variable_domain)
         var_optionals = myClorm.findInPropagateInit(ctl, atom.Propagator_variable_declareOptional)
+
+        from_facts_literals: dict[symbol_var, int] = {}
         for (name, symbol_var, domain), __literal in var_declares.items():
-            variable: Variable = Variable(name, symbol_var)
+            if symbol_var not in self.symbol2var:
+                variable: Variable = Variable(name, symbol_var)
+                self.symbol2var[symbol_var] = variable
+            else:
+                variable: Variable = cast(Variable, self.symbol2var[symbol_var])
 
-            if symbol_var in self.symbol2var:
-                self.errors.append(
-                    (
-                        warning.Variable(warning.VariableWarning.multipleDeclarations),
-                        f"Variable '{symbol_var}' declared multiple times!",
-                    )
-                )
+            ctl.add_watch(__literal)
+            ctl.add_watch(-__literal)
 
-            self.symbol2var[symbol_var] = variable
+            if __literal not in self.literal2var:
+                self.literal2var[__literal] = []
 
-            if __literal != 1:
-                self.errors.append(
-                    (warning.Propagator(), SyntaxError(f"Variable '{symbol_var}' declaration is not a fact!"))
-                )
+            self.literal2var[__literal].append(variable)
 
             if isinstance(domain, atom.BoolDomain):
                 literal_true = ctl.add_literal(freeze=True)
                 literal_false = ctl.add_literal(freeze=True)
-                variable.add_value(expression.Val(expression.BaseType.bool, True), literal_true)
-                variable.add_value(expression.Val(expression.BaseType.bool, False), literal_false)
+                variable.add_value(expression.Val(expression.BaseType.bool, True), literal_true, __literal)
+                variable.add_value(expression.Val(expression.BaseType.bool, False), literal_false, __literal)
                 ctl.add_watch(literal_true)
                 ctl.add_watch(-literal_true)
                 ctl.add_watch(literal_false)
                 ctl.add_watch(-literal_false)
 
+                # if the declaration is False, then the value it can give can not be true
+                ctl.add_clause([-literal_true, __literal])
+                ctl.add_clause([-literal_false, __literal])
+
+                self.literal2var[literal_true] = [variable]
+                self.literal2var[literal_false] = [variable]
+
             elif isinstance(domain, atom.FromList):
                 for expr in domain.elements:
                     literal = ctl.add_literal(freeze=True)
-                    variable.add_value(expr, literal)
+                    variable.add_value(expr, literal, __literal)
                     ctl.add_watch(literal)
                     ctl.add_watch(-literal)
 
+                    ctl.add_clause([-literal, __literal])
+
+                    self.literal2var[literal] = [variable]
+
             elif isinstance(domain, atom.FromFacts):
                 # values will be added from facts, nothing to do here
-                pass
+                from_facts_literals[symbol_var] = __literal
             else:
                 self.errors.append(
                     (warning.Propagator(), ValueError(f"Unknown domain type '{domain}' for variable '{symbol_var}'"))
@@ -544,11 +554,17 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 define_variable = Variable(name, symbol_var)
                 self.symbol2var[symbol_var] = define_variable
 
-            define_variable.add_value(expr, __literal)
+            define_variable.add_value(expr, __literal, __literal)
             ctl.add_watch(__literal)
             ctl.add_watch(-__literal)
 
+            if __literal not in self.literal2var:
+                self.literal2var[__literal] = []
+            self.literal2var[__literal].append(define_variable)
+            # here we dont add a nogood since its the same literal
+
         for (symbol_var, domain_expr), __literal in var_domains.items():
+            # These values are assgiend the "from_facts" domain literal for the given variable
             if symbol_var not in self.symbol2var:
                 self.errors.append(
                     (
@@ -559,16 +575,38 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 continue
             domain_variable: Variable = cast(Variable, self.symbol2var[symbol_var])
             literal = ctl.add_literal(freeze=True)
-            domain_variable.add_value(domain_expr, literal)
+            domain_literal = from_facts_literals[symbol_var]
+            domain_variable.add_value(domain_expr, literal, domain_literal)
             ctl.add_watch(literal)
             ctl.add_watch(-literal)
 
+            ctl.add_clause([-literal, domain_literal])
+
+            self.literal2var[literal] = [domain_variable]
+
         for (optional,), __literal in var_optionals.items():
+            if optional not in self.symbol2var:
+                # If the optinal variable is not declared we add a warning, since this is probably not intended
+                self.errors.append(
+                    (
+                        warning.Variable(warning.VariableWarning.undeclared),
+                        f"Variable '{optional}' declared optional but variable not declared!",
+                    )
+                )
+                continue
+
             optional_variable: Variable = cast(Variable, self.symbol2var[optional])
             literal = ctl.add_literal(freeze=True)
-            optional_variable.add_value(expression.Val(expression.BaseType.none, None), literal)
+            optional_variable.add_value(expression.Val(expression.BaseType.none, None), literal, __literal)
             ctl.add_watch(literal)
             ctl.add_watch(-literal)
+
+            ctl.add_clause([-literal, __literal])
+
+            if __literal not in self.literal2var:
+                self.literal2var[__literal] = []
+            self.literal2var[__literal].append(optional_variable)
+            self.literal2var[literal] = [optional_variable]
 
         # check that all variables have a domain
         for var in self.symbol2var.values():
@@ -592,7 +630,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 variable = Variable(name, symbol_var)
                 self.symbol2var[symbol_var] = variable
 
-            variable.add_value(expr, literal)
+            variable.add_value(expr, literal, literal)
             if literal not in self.literal2var:
                 self.literal2var[literal] = []
             self.literal2var[literal].append(variable)

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -1051,6 +1051,12 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 self.symbol2var[symbol_var].parents.append(var)
 
     def update_python_model(self):
+        """Build the python-side model representation from current variable values.
+
+        Populates `self.python_model` with result atoms (values, sets, multimaps,
+        evaluated atoms) and warning atoms. This is used by `on_model` to extend
+        the clingo model and by brave/cautious reasoning to accumulate results.
+        """
         self.python_model = set()
 
         for var in self.symbol2var.values():
@@ -1094,6 +1100,11 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         self.handle_on_model_warning(self.errors)
 
     def on_model(self, model: clingo.Model):
+        """Extend the clingo model with python-side result atoms.
+
+        Args:
+            model: Current clingo model.
+        """
         # add to the clingo output the final result based on reasoning mode
         # For brave and cautious, we output the accumulated result (similar to clingo)
         # For standard, we output the current model
@@ -1106,6 +1117,12 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 model.extend([clAtom])
 
     def handle_on_model_value(self, var: clingo.Symbol, final_value: Any):
+        """Dispatch model export based on the final value type.
+
+        Args:
+            var: Variable symbol.
+            final_value: Evaluated value for the variable.
+        """
         if final_value is ValueStatus.NOT_SET:
             assert False, f"Variable {var} has no value set in on_model!"
 
@@ -1122,6 +1139,12 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             myprint(f"Unknown model type {type(final_value)} for variable {var} in on_model!")
 
     def handle_on_model_set(self, var: clingo.Symbol, final_value: set | frozenset):
+        """Add atoms for a set-typed variable to the python model.
+
+        Args:
+            var: Variable symbol.
+            final_value: Set/frozenset value.
+        """
         assert self.python_model is not None
 
         pyVal = expression.Val(
@@ -1140,6 +1163,12 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             self.python_model.add(set_pyAtom)
 
     def handle_on_model_dict(self, var: clingo.Symbol, final_value: dict):
+        """Add atoms for a dict/multimap-typed variable to the python model.
+
+        Args:
+            var: Variable symbol.
+            final_value: Mapping value (may be a `HashableDict`).
+        """
         assert self.python_model is not None
 
         pyVal = expression.Val(evaluator.get_baseType(final_value), var)
@@ -1158,6 +1187,12 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 self.python_model.add(mm_pyAtom)
 
     def handle_on_model_normal_type(self, var: clingo.Symbol, final_value: bool | int | float | str | clingo.Symbol):
+        """Add atoms for a scalar variable (bool/int/float/str/symbol) to the python model.
+
+        Args:
+            var: Variable symbol.
+            final_value: Scalar value.
+        """
         assert self.python_model is not None
 
         pyVal = expression.Val(evaluator.get_baseType(final_value), final_value)
@@ -1165,6 +1200,11 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         self.python_model.add(pyAtom)
 
     def handle_on_model_warning(self, errors: propagator_warning_t):
+        """Add warning atoms to the python model.
+
+        Args:
+            errors: Iterable of warning atoms.
+        """
         assert self.python_model is not None
 
         for __warning in errors:

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -43,7 +43,36 @@ def myprint(*args, **kwargs):
 
 
 class ConstraintHandlerPropagator(clingo.Propagator):
+    """
+    Propagator that evaluates constraint_handler variables during solving.
+
+    The propagator maintains a mapping from clingo symbols and solver literals to
+    variable objects (see `constraint_handler.PropagatorVariables`). During
+    propagation/check it evaluates affected variables, checks ensure constraints,
+    and can add nogoods for conflicts or for pruning based on optimization or reasoning mode(brave/cautious).
+
+    Attributes:
+        symbol2var: Maps variable symbols to variable objects.
+        literal2var: Maps solver literals to variable objects.
+        evaluatevars: List of `EvaluateVariable` instances to evaluate.
+        optimization_sum: Optimization handler tracking objective sums.
+        best_value: Current best objective optimization vector.
+        using_optimization: Whether optimization is active.
+        optimization_strength: Whether equal quality solutions are allowed when optimizing.
+        environment: Evaluation environment built from solver identifier.
+        check_only: If True, `propagate` becomes a no-op. Will only evaluate variables in `check`.
+        errors: Warnings collected while evaluating variables or reading the input program.
+        reasoning_mode: STANDARD/BRAVE/CAUTIOUS mode.
+        python_model: Stores the python-level model for output.
+    """
+
     def __init__(self, check_only: bool = False):
+        """
+        Initialize the propagator.
+
+        Args:
+            check_only: If True, do not perform propagation (only allow checks).
+        """
         self.symbol2var: dict[clingo.Symbol, VariableType] = {}
         self.literal2var: dict[int, list[VariableType]] = {}
 
@@ -74,6 +103,15 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         self.forbidden_warnings: dict[warning.Kind, int] = {}
 
     def get_configuration(self, ctl: clingo.Control):
+        """
+        Read clingo configuration and initialize reasoning-mode settings.
+
+        For brave/cautious modes, this configures the solver heuristic and adds a
+        helper program to facilitate the reasoning stages.
+
+        Args:
+            ctl: Clingo control instance.
+        """
         match ctl.configuration.solve.enum_mode:  # ty:ignore[unresolved-attribute]
             case "brave":
                 self.reasoning_mode = ReasoningMode.BRAVE
@@ -89,6 +127,13 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         myprint(f"Propagator reasoning mode set to {self.reasoning_mode}")
 
     def init(self, init: clingo.PropagateInit) -> None:
+        """
+        Function implementing the init method of a Propagator.
+        See clingo Propagator documentation for more details.
+
+        Args:
+            init: Clingo PropagateInit object
+        """
         self.symbol2var.clear()
         self.literal2var.clear()
         self.evaluatevars.clear()
@@ -118,9 +163,14 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def add_reasoning_mode_helper_atoms(self, ctl: clingo.PropagateInit) -> None:
         """
-        This method adds helper atoms for brave and cautious reasoning modes.
-        An atom marks the stage where we let clingo do the reasoning for variables handled by the solver
-        The second atom marks the stage where we evaluate the atoms of the propagator.
+        Register helper literals for brave/cautious reasoning.
+
+        In brave/cautious mode, the encoding provides stage atoms that separate
+        (1) clingo reasoning for solver-handled variables and (2) propagator-side
+        evaluation.
+
+        Args:
+            ctl: Clingo PropagateInit object.
         """
         if self.reasoning_mode in (ReasoningMode.BRAVE, ReasoningMode.CAUTIOUS):
             myprint("Adding reasoning mode helper atoms")
@@ -145,9 +195,15 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def set_optimization_check_strength(self, strength: Literal["lt", "le"]) -> None:
         """
-        This method sets the optimization check strength.
-        'lt' means that only better solutions are accepted(i.e. solution with lower sum).
-        'le' means that better or equal solutions are accepted(i.e. solution with lower or equal sum).
+        Configure whether optimization pruning requires strict improvement.
+
+        Args:
+            strength: Comparison mode.
+                - `"lt"`: only strictly better solutions are accepted.
+                - `"le"`: better or equal solutions are accepted.
+
+        Raises:
+            ValueError: If `strength` is not one of `"lt"` or `"le"`.
         """
 
         assert strength in ("lt", "le"), f"Unknown optimization check strength: {strength}"
@@ -161,17 +217,23 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def set_optimization_best_value(self, value: list[int | float]) -> None:
         """
-        This method sets the best optimization value.
+        Set the best (incumbent) optimization value used for pruning.
+
+        Args:
+            value: Objective vector ordered by priority.
         """
         self.best_value = value
 
     def check(self, control: clingo.PropagateControl) -> None:
         """
-        This method is called to check the constraints in the propagator.
-        It evaluates all variables in case there were changes from the last propagation call.
-        It then evaluates the optimization sums.
-        If a variable evaluation has a conflict, any ensure constraint is violated
-        or the optimization value is below the best it adds a nogood and backtracks.
+        Perform a full consistency check using the current solver assignment.
+
+        This evaluates all variables, checks ensure constraints and forbidden
+        warnings, and applies optimization pruning by adding nogoods when
+        necessary.
+
+        Args:
+            control: Clingo PropagateControl object.
         """
         myprint("CHECKING")
         if self.add_nogoods_from_queue(control):
@@ -197,6 +259,15 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             self.check_total(control)
 
     def check_total(self, control: clingo.PropagateControl) -> None:
+        """
+        Handle a total assignment.
+
+        This evaluates `evaluate` atoms, updates the python-side model for
+        brave/cautious reasoning, and updates the incumbent objective value.
+
+        Args:
+            control: Clingo PropagateControl object.
+        """
         self.check_evaluate(control)
         backtrack = self.evaluate_model(control)
         myprint(f"Standard/Brave/Cautious model evaluated to {self.python_model}")
@@ -212,6 +283,19 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             self.best_value = self.optimization_sum.get_value()
 
     def evaluate_model(self, ctl: clingo.PropagateControl) -> bool:
+        """
+        Update and (if needed) refine the accumulated python model.
+
+        In STANDARD mode this only rebuilds the python model and never
+        backtracks. In BRAVE/CAUTIOUS mode, the model is accumulated across
+        models and nogoods may be enqueued to force progress between stages.
+
+        Args:
+            ctl: Clingo propagation control.
+
+        Returns:
+            bool: True if nogoods were added and propagation should stop.
+        """
         old_model = self.python_model
         self.update_python_model()
 
@@ -268,15 +352,19 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def get_reasoning_mode_nogoods(self, variables: set[atom.ResultAtom], first_call) -> list[Iterable[int]]:
         """
-        Add nogoods for brave/cautious reasoning mode based on the variables in the model.
-        For brave reasoning, we add nogoods to ensure that the next models found contain at least 1 variable with a different value.
-        This way we expand the amount of values in the brave model after every model found.
+        Create nogoods used to drive brave/cautious reasoning.
 
-        For Cautious reasoning, on the first call, we add nogoods to ensure that the next models found contain at least 1 variable with a different value.
-        Similar to brave reasoning.
-        On Subsequent calls, we expect that the variable in the argument is the difference between the old and new model.
-        Specifically, the variables which CHANGED.
-        For those variables, we add a nogood to disable the change for that variable.
+        - BRAVE: force the next model to differ in at least one variable so the
+            accumulated model can grow.
+        - CAUTIOUS: on first call behaves like brave; on subsequent calls, block
+            exactly the changes observed to converge to the intersection.
+
+        Args:
+                variables: Result atoms relevant for the current step.
+                first_call: Whether this is the first stage-2 call for the run.
+
+        Returns:
+                list[Iterable[int]]: Nogoods to add (each is a collection of solver literals).
         """
         assert self.reasoning_mode in (ReasoningMode.BRAVE, ReasoningMode.CAUTIOUS)
 
@@ -307,8 +395,13 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def add_nogoods_from_queue(self, ctl: clingo.PropagateControl) -> bool:
         """
-        Add nogoods from queue until propagation must be stopped or queue is empty.
-        returns True if propagation must be stopped
+        Add queued nogoods until the queue is empty or clingo refuses one.
+
+        Args:
+            ctl: Clingo PropagateControl object.
+
+        Returns:
+            bool: True if adding a nogood failed (propagation must stop).
         """
         while len(self.nogood_queue) > 0:
             ng = self.nogood_queue.pop(0)
@@ -318,6 +411,12 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         return False
 
     def check_evaluate(self, ctl: clingo.PropagateControl):
+        """
+        Evaluate `evaluate` atoms against the current assignments.
+
+        Args:
+            ctl: Clingo PropagateControl object.
+        """
         myprint("Checking evaluate atoms")
         myprint(f"Evaluated assignments before evaluate: {make_dict_from_variables(self.symbol2var.values())}")
         for var in self.evaluatevars:
@@ -325,11 +424,13 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def propagate(self, control: clingo.PropagateControl, changes: Sequence[int]) -> None:
         """
-        This method is called to propagate the constraints in the propagator.
-        It evaluates the expressions assigned to variables and checks the ensures.
-        If a variable evaluation has a conflict, any ensure constraint is violated
-        or the optimization value if below the best and has been completely assigned
-        it adds a nogood and backtracks.
+        Propagate after a solver assignment change.
+        Checks which variables are affected by the change, evaluates them,
+        and applies optimization pruning if enabled.
+
+        Args:
+            control: Clingo propagation control.
+            changes: Sequence of (signed) solver literals that changed.
         """
         if self.check_only:
             return
@@ -357,11 +458,17 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def evaluate_optimization_sum(self, ctl: clingo.PropagateControl) -> bool:
         """
-        This method evaluates the optimization sum in the propagator.
-        It uses the current solver assignment to determine its value.
-        If the optimization sum value is worse than the best value and all variables are assigned,
-        it adds a nogood to enforce the optimization.
-        return True if a backtrack is needed, False otherwise.
+        Evaluate the current objective value and optionally prune.
+
+        If the objective is already worse than the incumbent and the relevant
+        parts are fully assigned, a nogood is added to exclude the current
+        partial/total assignment.
+
+        Args:
+            ctl: Clingo propagation control.
+
+        Returns:
+            bool: True if a nogood was added requiring a backtrack.
         """
         if not self.using_optimization:
             return False
@@ -398,6 +505,16 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         return False
 
     def add_nogood_for_variable(self, ctl: clingo.PropagateControl, var: VariableType | OptimizationHandler) -> None:
+        """
+        Add a nogood blocking the current assignment for a variable.
+
+        The nogood is constructed from the literals that explain the variable's
+        current value.
+
+        Args:
+            ctl: Clingo PropagateControl object.
+            var: Variable (or optimization handler) to block.
+        """
         ng: set[int] = set()
         for symbol_var in var.vars():
             v = self.symbol2var[symbol_var]
@@ -408,10 +525,17 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def evaluated_solver_assignment(self, ctl: clingo.PropagateControl, to_evaluate: set[VariableType]) -> bool:
         """
-        This method evaluates the variables given using the current solver assignment.
-        If a variable's value changes, it also evaluates its parents.
-        Return value should say if a backtrack is needed!
-        It returns False if a conflict is detected (No backtracking needed), True otherwise.
+        Evaluate a set of variables under the current solver assignment.
+
+        If a variable changes, its parents are scheduled for evaluation.
+
+        Args:
+            ctl: Clingo PropagateControl object.
+            to_evaluate: Variables that may have been affected by recent changes.
+
+        Returns:
+            bool: True if propagation should stop (conflict/forbidden warning),
+            False otherwise.
         """
         while len(to_evaluate) > 0:
             var = to_evaluate.pop()
@@ -430,10 +554,17 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def evaluate_variable(self, ctl: clingo.PropagateControl, var: VariableType) -> bool | None:
         """
-        This method evaluates a variable in the propagator.
-        It uses the current solver assignment to determine its value.
-        It returns True if the variable's value changed, False if it did not change,
-        and None if there was a conflict.
+        Evaluate one variable against the current assignment.
+
+        Args:
+            ctl: Clingo PropagateControl object.
+            var: Variable to evaluate.
+
+        Returns:
+            bool | None:
+                - True if the variable's value changed.
+                - False if it did not change.
+                - None if evaluation detected a conflict (nogood added).
         """
         eval_result: EvaluationResult = var.evaluate(
             make_dict_from_variables(self.symbol2var.values()), ctl, self.environment
@@ -467,6 +598,17 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         return eval_result == EvaluationResult.CHANGED
 
     def get_reasons(self, var: VariableType) -> set[int]:
+        """Compute the set of literals explaining a variable's current value.
+
+        This is used when constructing nogoods for conflicts, forbidden warnings,
+        and optimization pruning.
+
+        Args:
+            var: Variable whose reasons should be collected.
+
+        Returns:
+            set[int]: Set of signed solver literals.
+        """
         reasons = var.literals
         for dvar in var.vars():
             if dvar.name == EXECUTION_OUTPUT:
@@ -477,7 +619,15 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def undo(self, thread_id: int, assignment: clingo.Assignment, changes: Sequence[int]) -> None:
         """
-        Resets the evaluations and reasons based on the current assignment.
+        Undo propagator state on backtracking.
+
+        This resets variable evaluations whose decision level is higher or equal to the current backtracking level
+        and clears derived optimization state.
+
+        Args:
+            thread_id: Clingo thread id (unused).
+            assignment: Current assignment after backtracking.
+            changes: Literals undone by clingo.
         """
         myprint(f"UNDOING for decision level {assignment.decision_level} with changes {changes}")
         for var in self.symbol2var.values():
@@ -490,9 +640,12 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def get_variables(self, ctl: clingo.PropagateInit):
         """
-        This method initializes the variables from the ASP encoding.
-        It reads the propagator_variable_declare, propagator_variable_define, propagator_variable_domain
-        atoms and creates Variable instances.
+        Load base variable declarations/definitions/domains from ASP facts.
+
+        Reads variable-related atoms and creates/extends `Variable` instances.
+
+        Args:
+            ctl: Clingo PropagateInit object.
         """
         var_declares = myClorm.findInPropagateInit(ctl, atom.Propagator_variable_declare)
         var_defines = myClorm.findInPropagateInit(ctl, atom.Propagator_variable_define)
@@ -641,8 +794,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def get_assign(self, ctl: clingo.PropagateInit):
         """
-        This method initializes the variables from the ASP encoding.
-        It reads the propagator_assign atoms and creates Variable instances.
+        Load `propagator_assign/..` atoms and attach values to variables.
+
+        Args:
+            ctl: Clingo PropagateInit object.
         """
 
         assigns = myClorm.findInPropagateInit(ctl, atom.Propagator_assign)
@@ -664,8 +819,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def get_ensure(self, ctl: clingo.PropagateInit):
         """
-        This method initializes the ensure constraints from the ASP encoding.
-        It reads the propagator_ensure atoms and stores them with their literals.
+        Load ensure constraints from ASP facts and create EnsureVariable instances.
+
+        Args:
+            ctl: Clingo PropagateInit object.
         """
 
         ensures = myClorm.findInPropagateInit(ctl, atom.Propagator_ensure)
@@ -682,8 +839,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def get_evaluate(self, ctl: clingo.PropagateInit):
         """
-        This method initializes the variables from the ASP encoding.
-        It reads the evaluate atoms and creates EvaluateVariable instances.
+        Load `evaluate` atoms into `EvaluateVariable` instances.
+
+        Args:
+            ctl: Clingo PropagateInit object.
         """
 
         for (op, args), literal in myClorm.findInPropagateInit(ctl, atom.Propagator_evaluate).items():
@@ -700,7 +859,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def get_solver_identifier(self, ctl: clingo.PropagateInit):
         """
-        This method initializes the solver identifier from the ASP encoding.
+        Initialize the Python evaluation environment using the solver identifier.
+
+        Args:
+            ctl: Clingo PropagateInit object.
         """
 
         for id, _ in myClorm.findInPropagateInit(ctl, atom.Main_solverIdentifier).items():
@@ -708,8 +870,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def get_optimization_sums(self, ctl: clingo.PropagateInit):
         """
-        This method initializes the optimization sum from the ASP encoding.
-        It reads the optimize_maximizeSum atoms and creates an OptimizationSum instance.
+        Load optimization sum declarations from ASP facts and create OptimizationSum instances.
+
+        Args:
+            ctl: Clingo PropagateInit object.
         """
 
         maxSums = myClorm.findInPropagateInit(ctl, atom.Propagator_optimize_maximizeSum)
@@ -721,8 +885,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def get_set_declarations(self, ctl: clingo.PropagateInit):
         """
-        This method initializes the set variables from the ASP encoding.
-        It reads the set_declare and set_assign atoms and creates SetVariable instances.
+        Load set declarations and assignments from ASP facts.
+
+        Args:
+            ctl: Clingo propagation initializer.
         """
 
         declares = myClorm.findInPropagateInit(ctl, atom.Propagator_set_declare)
@@ -758,8 +924,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def get_multimap_declarations(self, ctl: clingo.PropagateInit):
         """
-        This method initializes the dict variables from the ASP encoding.
-        It reads the multimap_declare and multimap_assign atoms and creates DictVariable instances.
+        Load multimap (dict) declarations and assignments from ASP facts.
+
+        Args:
+            ctl: Clingo PropagateInit object.
         """
         declares = myClorm.findInPropagateInit(ctl, atom.Propagator_multimap_declare)
         for (name, symbol_var), literal in declares.items():
@@ -795,8 +963,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def get_execution_declarations(self, ctl: clingo.PropagateInit):
         """
-        This method initializes the execution declarations from the ASP encoding.
-        It reads the execution_declare and execution_run atoms and creates Execution instances.
+        Load execution blocks and run-atoms from ASP facts and create Execution instances.
+
+        Args:
+            ctl: Clingo PropagateInit object.
         """
         declares = myClorm.findInPropagateInit(ctl, atom.Propagator_execution_declare)
         for (name, symbol_var, stmt, in_v, out_v), literal in declares.items():
@@ -836,7 +1006,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def get_forbidden_warnings(self, ctl) -> None:
         """
-        Returns the list of forbidden warnings given by the atoms in the input program.
+        Load `forbid_warning` atoms.
+
+        Args:
+            ctl: Clingo propagation initializer.
         """
 
         forbidden_warnings = myClorm.findInPropagateInit(ctl, warning.Forbid_warning)
@@ -855,7 +1028,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
     def set_parents(self):
         """
-        Sets the parents of each variable based on the variables they depend on.
+        Populate parent relationships between variables.
+
+        Parents are variables that depend on another variable's value; if a child
+        changes, parents are scheduled for re-evaluation.
         """
         for var in self.symbol2var.values():
             for symbol_var in var.vars():

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -19,10 +19,10 @@ from constraint_handler.PropagatorConstants import (
     REASONING_MODE_PROGRAM,
     REASONING_STAGE_ATOM,
     EvaluationResult,
-    NoValueSet,
     OptimizationStrength,
     ReasoningMode,
     ValueStatus,
+    propagator_warning_t,
 )
 from constraint_handler.PropagatorVariables import (
     DictVariable,
@@ -58,7 +58,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         self.check_only = check_only
 
-        self.errors: list[tuple[warning.Kind, Any]] = []
+        self.errors: propagator_warning_t = []
 
         self.reasoning_mode: ReasoningMode = ReasoningMode.STANDARD
         self.reasoning_mode_stage_lits: dict[Literal[1, 2, 3], int] = {1: -1, 2: -1, 3: -1}
@@ -71,10 +71,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         self.nogood_queue: list[Iterable[int]] = []
         self.previously_stage_2: bool = False
 
-        self.forbidden_warnings: list[warning.Kind] = []
+        self.forbidden_warnings: dict[warning.Kind, int] = {}
 
     def get_configuration(self, ctl: clingo.Control):
-        match ctl.configuration.solve.enum_mode:  # ty:ignore[possibly-missing-attribute]
+        match ctl.configuration.solve.enum_mode:  # ty:ignore[unresolved-attribute]
             case "brave":
                 self.reasoning_mode = ReasoningMode.BRAVE
             case "cautious":
@@ -449,15 +449,17 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             return None
 
         # check if any errors are forbidden
-        for error, msg in var.get_errors():
-            if error in self.forbidden_warnings:
-                myprint(f"Forbidden warning {(error, msg)} exists, making program unsat!")
-                ng = self.get_reasons(var)
-                myprint(f"Adding nogood {ng}")
-                if ctl.add_nogood(ng):
-                    assert False, (
-                        f"Added violated constraint but solver did not detect it for variable {var} with reasons {ng}",
-                    )
+        for __warning in var.get_errors():
+            if __warning.id in self.forbidden_warnings:
+                literal = self.forbidden_warnings[__warning.id]
+                if ctl.assignment.is_true(literal):
+                    myprint(f"Forbidden warning {(__warning, literal)} exists, making program unsat!")
+                    ng = self.get_reasons(var)
+                    myprint(f"Adding nogood {ng}")
+                    if ctl.add_nogood(ng):
+                        assert False, (
+                            f"Added violated constraint but solver did not detect it for variable {var} with reasons {ng}",
+                        )
                     return None
 
         return eval_result == EvaluationResult.CHANGED
@@ -514,8 +516,12 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             if isinstance(domain, atom.BoolDomain):
                 literal_true = ctl.add_literal(freeze=True)
                 literal_false = ctl.add_literal(freeze=True)
-                variable.add_value(expression.Val(expression.BaseType.bool, True), literal_true, __literal)
-                variable.add_value(expression.Val(expression.BaseType.bool, False), literal_false, __literal)
+                variable.add_value(
+                    expression.Val(expression.BaseType.bool, True), literal_true, __literal
+                )  # ty:ignore[unresolved-attribute]
+                variable.add_value(
+                    expression.Val(expression.BaseType.bool, False), literal_false, __literal
+                )  # ty:ignore[unresolved-attribute]
                 ctl.add_watch(literal_true)
                 ctl.add_watch(-literal_true)
                 ctl.add_watch(literal_false)
@@ -544,7 +550,11 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 from_facts_literals[symbol_var] = __literal
             else:
                 self.errors.append(
-                    (warning.Propagator(), ValueError(f"Unknown domain type '{domain}' for variable '{symbol_var}'"))
+                    warning.Warning(
+                        warning.Propagator(),
+                        (symbol_var,),
+                        f"Unknown domain type '{domain}' for variable '{symbol_var}'",
+                    )
                 )
 
         for (name, symbol_var, expr), __literal in var_defines.items():
@@ -567,8 +577,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             # These values are assgiend the "from_facts" domain literal for the given variable
             if symbol_var not in self.symbol2var:
                 self.errors.append(
-                    (
-                        warning.Variable(warning.VariableWarning.undeclared),
+                    warning.Warning(
+                        warning.Variable(warning.VariableWarning.undeclared),  # ty:ignore[unresolved-attribute]
+                        (symbol_var,),
                         f"Variable '{symbol_var}' domain set but variable not declared!",
                     )
                 )
@@ -588,8 +599,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             if optional not in self.symbol2var:
                 # If the optinal variable is not declared we add a warning, since this is probably not intended
                 self.errors.append(
-                    (
-                        warning.Variable(warning.VariableWarning.undeclared),
+                    warning.Warning(
+                        warning.Variable(warning.VariableWarning.undeclared),  # ty:ignore[unresolved-attribute]
+                        (optional,),
                         f"Variable '{optional}' declared optional but variable not declared!",
                     )
                 )
@@ -597,7 +609,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
             optional_variable: Variable = cast(Variable, self.symbol2var[optional])
             literal = ctl.add_literal(freeze=True)
-            optional_variable.add_value(expression.Val(expression.BaseType.none, None), literal, __literal)
+            optional_variable.add_value(
+                expression.Val(expression.BaseType.none, None), literal, __literal
+            )  # ty:ignore[unresolved-attribute]
             ctl.add_watch(literal)
             ctl.add_watch(-literal)
 
@@ -612,7 +626,11 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         for var in self.symbol2var.values():
             if not var.has_domain():
                 self.errors.append(
-                    (warning.Variable(warning.VariableWarning.emptyDomain), f"Variable '{var}' has no domain defined!")
+                    warning.Warning(
+                        warning.Variable(warning.VariableWarning.emptyDomain),  # ty:ignore[unresolved-attribute]
+                        (var,),
+                        f"Variable '{var}' has no domain defined!",
+                    )
                 )
 
     def get_assign(self, ctl: clingo.PropagateInit):
@@ -666,7 +684,11 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             var = EvaluateVariable(op, args, literal)
             if literal != 1:
                 self.errors.append(
-                    (warning.Propagator(), SyntaxError(f"Evaluate atom {op} with args {args} is not a fact!"))
+                    warning.Warning(
+                        warning.Propagator(),
+                        (var,),
+                        f"Evaluate atom {op} with args {args} is not a fact!",
+                    )
                 )
             self.evaluatevars.append(var)
 
@@ -702,9 +724,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             variable = SetVariable(name, symbol_var, literal)
             if literal != 1:
                 self.errors.append(
-                    (
+                    warning.Warning(
                         warning.Propagator(),
-                        SyntaxError(f"Set variable {name} declaration is not a fact! It has literal {literal}."),
+                        (variable,),
+                        f"Set variable {name} declaration is not a fact! It has literal {literal}.",
                     )
                 )
 
@@ -738,9 +761,10 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
             if literal != 1:
                 self.errors.append(
-                    (
+                    warning.Warning(
                         warning.Propagator(),
-                        SyntaxError(f"Dict variable {symbol_var} declaration is not a fact! It has literal {literal}."),
+                        (variable,),
+                        f"Dict variable {symbol_var} declaration is not a fact! It has literal {literal}.",
                     )
                 )
 
@@ -785,8 +809,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         for (name, symbol_var), literal in exec_runs.items():
             if symbol_var not in self.symbol2var:
                 self.errors.append(
-                    (
-                        warning.Variable(warning.VariableWarning.undeclared),
+                    warning.Warning(
+                        warning.Variable(warning.VariableWarning.undeclared),  # ty:ignore[unresolved-attribute]
+                        (symbol_var,),
                         f"Execution variable '{symbol_var}' run exists but variable not declared!",
                     )
                 )
@@ -807,15 +832,17 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         forbidden_warnings = myClorm.findInPropagateInit(ctl, warning.Forbid_warning)
         for (name, error), literal in forbidden_warnings.items():
-            self.forbidden_warnings.append(error)
+            self.forbidden_warnings[error] = literal
 
         # If a forbidden warning exists already, add empty constraint to make the program unsat
         # Since the warning comes from just reading the input
-        for error, msg in self.errors:
-            if error in self.forbidden_warnings:
-                myprint(f"Forbidden warning {(error, msg)} exists, making program unsat!")
-                ctl.add_clause([])
-                return
+        for __warning in self.errors:
+            if __warning.id in self.forbidden_warnings:
+                literal = self.forbidden_warnings[__warning.id]
+                if ctl.assignment.is_true(literal):
+                    myprint(f"Forbidden warning {__warning} exists, making program unsat!")
+                    ctl.add_clause([])
+                    return
 
     def set_parents(self):
         """
@@ -848,7 +875,9 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             final_value = var.get_value()
             # myprint(var.var, final_value, type(final_value))
             if final_value is ValueStatus.NOT_SET:
-                self.errors.append((warning.Propagator(), NoValueSet(f"Variable {var} has no value set in on_model!")))
+                self.errors.append(
+                    warning.Warning(warning.Propagator(), (var,), "Variable has no value set in on_model!")
+                )
                 continue
 
             if final_value is ValueStatus.ASSIGNMENT_IS_FALSE:
@@ -908,6 +937,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             myprint(f"Unknown model type {type(final_value)} for variable {var} in on_model!")
 
     def handle_on_model_set(self, var: clingo.Symbol, final_value: set | frozenset):
+        assert self.python_model is not None
+
         pyVal = expression.Val(
             evaluator.get_baseType(final_value), clingo.Function("ref", [clingo.Function("variable", [var])])
         )
@@ -924,12 +955,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             self.python_model.add(set_pyAtom)
 
     def handle_on_model_dict(self, var: clingo.Symbol, final_value: dict):
-        # TODO: If we want to use the ref system for the output here(for sets, etc) then
-        # we have to loop over the expressions in the dict, not just the final values
-        # otherwise, we don't know what the ref is for each key and value
-        # alternatively, we have a separate part of the dict that tells you which refs are for which key/value
+        assert self.python_model is not None
 
-        # TODO: Type for dict is not handled here which results in a none value being output for the type in the value atom
         pyVal = expression.Val(evaluator.get_baseType(final_value), var)
         pyAtom = atom.Value(var, pyVal)
         self.python_model.add(pyAtom)
@@ -946,11 +973,14 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 self.python_model.add(mm_pyAtom)
 
     def handle_on_model_normal_type(self, var: clingo.Symbol, final_value: bool | int | float | str | clingo.Symbol):
+        assert self.python_model is not None
+
         pyVal = expression.Val(evaluator.get_baseType(final_value), final_value)
         pyAtom = atom.Value(var, pyVal)
         self.python_model.add(pyAtom)
 
-    def handle_on_model_warning(self, errors: list[tuple[warning.Kind, Any]]):
-        for error_kind, msg in errors:
-            atom_ = warning.Warning(error_kind, tuple(), str(msg))
-            self.python_model.add(atom_)
+    def handle_on_model_warning(self, errors: propagator_warning_t):
+        assert self.python_model is not None
+
+        for __warning in errors:
+            self.python_model.add(__warning)

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -539,15 +539,11 @@ class ConstraintHandlerPropagator(clingo.Propagator):
 
         for (name, symbol_var, expr), __literal in var_defines.items():
             if symbol_var in self.symbol2var:
-                self.errors.append(
-                    (
-                        warning.Variable(warning.VariableWarning.multipleDefinitions),
-                        f"Variable '{symbol_var}' has multiple definitions!",
-                    )
-                )
-                continue
-            define_variable = Variable(name, symbol_var)
-            self.symbol2var[symbol_var] = define_variable
+                define_variable: Variable = cast(Variable, self.symbol2var[symbol_var])
+            else:
+                define_variable = Variable(name, symbol_var)
+                self.symbol2var[symbol_var] = define_variable
+
             define_variable.add_value(expr, __literal)
             ctl.add_watch(__literal)
             ctl.add_watch(-__literal)

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -643,6 +643,7 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         Load base variable declarations/definitions/domains from ASP facts.
 
         Reads variable-related atoms and creates/extends `Variable` instances.
+        Note that nogoods are added to prevent True assignments to values that are parts of domains that are assigned False.
 
         Args:
             ctl: Clingo PropagateInit object.

--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -1051,7 +1051,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 self.symbol2var[symbol_var].parents.append(var)
 
     def update_python_model(self):
-        """Build the python-side model representation from current variable values.
+        """
+        Build the python-side model representation from current variable values.
 
         Populates `self.python_model` with result atoms (values, sets, multimaps,
         evaluated atoms) and warning atoms. This is used by `on_model` to extend
@@ -1100,7 +1101,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         self.handle_on_model_warning(self.errors)
 
     def on_model(self, model: clingo.Model):
-        """Extend the clingo model with python-side result atoms.
+        """
+        Extend the clingo model using python-side result atoms.
 
         Args:
             model: Current clingo model.
@@ -1117,7 +1119,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 model.extend([clAtom])
 
     def handle_on_model_value(self, var: clingo.Symbol, final_value: Any):
-        """Dispatch model export based on the final value type.
+        """
+        Dispatch model export based on the final value type.
 
         Args:
             var: Variable symbol.
@@ -1139,7 +1142,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             myprint(f"Unknown model type {type(final_value)} for variable {var} in on_model!")
 
     def handle_on_model_set(self, var: clingo.Symbol, final_value: set | frozenset):
-        """Add atoms for a set-typed variable to the python model.
+        """
+        Add atoms for a set-typed variable to the python model.
 
         Args:
             var: Variable symbol.
@@ -1163,7 +1167,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             self.python_model.add(set_pyAtom)
 
     def handle_on_model_dict(self, var: clingo.Symbol, final_value: dict):
-        """Add atoms for a dict/multimap-typed variable to the python model.
+        """
+        Add atoms for a dict/multimap-typed variable to the python model.
 
         Args:
             var: Variable symbol.
@@ -1187,7 +1192,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
                 self.python_model.add(mm_pyAtom)
 
     def handle_on_model_normal_type(self, var: clingo.Symbol, final_value: bool | int | float | str | clingo.Symbol):
-        """Add atoms for a scalar variable (bool/int/float/str/symbol) to the python model.
+        """
+        Add atoms for a variable (bool/int/float/str/symbol) to the python model.
 
         Args:
             var: Variable symbol.
@@ -1200,7 +1206,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
         self.python_model.add(pyAtom)
 
     def handle_on_model_warning(self, errors: propagator_warning_t):
-        """Add warning atoms to the python model.
+        """
+        Add warning atoms to the python model.
 
         Args:
             errors: Iterable of warning atoms.

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -125,12 +125,8 @@ def test_engine_propagator(name, check_mode):
         "optimize_priority",
         "set_iterations",
         "set_selfref",
-        "warning_fake_forbid",
-        "warning_python",
-        "warning_type",
         "warning_variables",
         "warning_variable_undeclared",
-        "warning_variable_undeclared_statement",
     ]
     if name not in unsupported:
         run_test(name, "propagator", check_mode)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -127,6 +127,7 @@ def test_engine_propagator(name, check_mode):
         "set_selfref",
         "warning_variables",
         "warning_variable_undeclared",
+        "type_checking",
     ]
     if name not in unsupported:
         run_test(name, "propagator", check_mode)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -125,7 +125,6 @@ def test_engine_propagator(name, check_mode):
         "optimize_priority",
         "set_iterations",
         "set_selfref",
-        "variable_parallel_declaration",
         "warning_fake_forbid",
         "warning_python",
         "warning_type",


### PR DESCRIPTION
- Variables do not enforce a value in general, only if a "domain" atom(E.g. variable define) is true. Issue #130 
- Several bug fixes related to multimaps and executions
- Change default decision level and fix bugs related to it
- Warnings are only applied if their associated literal is True. Issue #131 
- Add doc strings to propagator related classes and methods