### PR TITLE
linear int eq implementation

### DIFF
--- a/src/constraint_handler/data/direct.lp
+++ b/src/constraint_handler/data/direct.lp
@@ -51,6 +51,16 @@ _direct_queryArgsValues(E,OP,ARGS) :- direct_query(E), E=operation(EOP,ARGS), _s
 _direct_doCompute(OP, ARGS) :- _direct_queryArgsValues(E, OP, ARGS), OP != add.
 _direct_doCompute(add, ARGS) :- _direct_queryArgsValues(E, add, ARGS),
     (_, ARG) = @pythonEnumerateElements(ARGS), type_expression((), ARG, T), T != int.
+
+% For `eq`, avoid building the fully-evaluated argument tuple if the operation
+% is a binary int equality. This case can be handled via _computedIdx/2 in
+% int.lp without Cartesian-product grounding.
+_direct_eq_int_int_binary(E, eq, ARGS) :- _direct_queryArgsValues(E, eq, ARGS),
+    ARGS = (A, (B, ())),
+    type_expression((), A, int),
+    type_expression((), B, int).
+_direct_doCompute(eq, ARGS) :- _direct_queryArgsValues(E, eq, ARGS), not _direct_eq_int_int_binary(E, eq, ARGS).
+
 %% _direct_compArg(ARGS,IDX,ARG) :- _direct_queryArgsValues(E,OP,ARGS), (IDX,ARG)=@pythonEnumerateElements(ARGS).
 %% _direct_compMapAux(ARGS,N,()) :- _direct_queryArgsValues(E,OP,ARGS), N=@pythonListLength(ARGS).
 %% _direct_compMapAux(ARGS,IDX,K) :- _direct_compMapAux(ARGS,IDX+1,L), _direct_compArg(ARGS,IDX,ARG), _se_value(ARG,T,V), K=(val(T,V),L).

--- a/src/constraint_handler/data/int.lp
+++ b/src/constraint_handler/data/int.lp
@@ -40,6 +40,21 @@ _computed(OP,ARGS,val(int,-V))  :- _compute(OP,ARGS), OP=minus, ARGS = (val(int,
 
 %%%%%%%%%%%%%%%%% comparison equality
 operator_declare(OP,(T,(T,())),bool) :- T = int, OP = (eq;neq;leq;lt;geq;gt).
+
+% Direct (compile-engine) computation for binary integer equality.
+% This avoids building the fully-evaluated argument tuple (and thus avoids
+% Cartesian-product grounding) by iterating over values of the first argument
+% and checking for a matching value in the second argument.
+%COULD BE CORRECT, but type inference is not ready yet
+_computedIdx(E, val(bool,true)) :- _direct_eq_int_int_binary(E, eq, ARGS),
+    E = operation(eq, (A, (B, ()))),
+    _computeIdx(E, 0, val(int, V1)),
+    _computeIdx(E, 1, val(int, V1)).
+_computedIdx(E, val(bool,false)) :- _direct_eq_int_int_binary(E, eq, ARGS),
+    E = operation(eq, (A, (B, ()))),
+    _computeIdx(E, 0, val(int, V1)),
+    not _computeIdx(E, 1, val(int, V1)).
+
 _computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=eq,  ARGS = (val(int,V1),(val(int,V2),())), V1 =  V2.
 _computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=neq, ARGS = (val(int,V1),(val(int,V2),())), V1 != V2.
 _computed(OP,ARGS,val(bool,true))  :- _compute(OP,ARGS), OP=leq, ARGS = (val(int,V1),(val(int,V2),())), V1 <= V2.


### PR DESCRIPTION
First try at linear (instead of quadratic) equality on the example of integers.
This is meant as food for thoughts, not an actual implementation. It currently builds on the integer aggregate branch #163 as the concept is similar.

This does not yet improve anything on larger examples as the internal typing system:
1. does not yet support any inferences
2. is not meant to be static? A lot of types are depending on _expression_query/2 which then means that no optimization can take place as everything has to be grounded. Maybe the typing system could be made static? (facts only)

@AbdallahS 