### PR TITLE
implement mult via computedIdx

### DIFF
--- a/src/constraint_handler/data/int.lp
+++ b/src/constraint_handler/data/int.lp
@@ -8,13 +8,20 @@ _computed(OP, ARGS, val(int, V1 + VTAIL)) :-
     ARGS = (val(int, V1), TAIL),
     _computed(OP, TAIL, val(int, VTAIL)).
 
-_computed(OP, ARGS, val(int, 1)) :- _compute(OP, ARGS), OP=mult, ARGS = ().
-_compute(OP, TAIL) :- _compute(OP, ARGS), OP=mult, ARGS = (val(int, _), TAIL).
-_computed(OP, ARGS, val(int, V1 * VTAIL)) :-
-    _compute(OP, ARGS),
-    OP=mult,
-    ARGS = (val(int, V1), TAIL),
-    _computed(OP, TAIL, val(int, VTAIL)).
+% _computed(OP, ARGS, val(int, 1)) :- _compute(OP, ARGS), OP=mult, ARGS = ().
+% _compute(OP, TAIL) :- _compute(OP, ARGS), OP=mult, ARGS = (val(int, _), TAIL).
+% _computed(OP, ARGS, val(int, V1 * VTAIL)) :-
+%     _compute(OP, ARGS),
+%     OP=mult,
+%     ARGS = (val(int, V1), TAIL),
+%     _computed(OP, TAIL, val(int, VTAIL)).
+
+% short circuit if there is a 0
+_computedIdx(E,val(int,0)) :- _computeIdx(E,mult), _computeIdx(E,IDX,val(int,0)).
+_computedIdx(E,val(int,1)) :- _computeIdx(E,mult), not _computeIdx(E, 0, _).
+_mult(E,0,val(int,1)) :- _computeIdx(E,mult).
+_mult(E,IDX+1,val(int,VO*V)) :- _computeIdx(E,mult), _computeIdx(E,IDX,val(int,V)), _mult(E,IDX,val(int,VO)).
+_computedIdx(E,V)  :- _computeIdx(E,mult), _mult(E,IDX,V),_computeIdx(E,IDX-1,_), not _computeIdx(E,IDX,_).
 
 %%%%%%%%%%%%%%%%% sub int_div pow
 operator_declare(OP,(T,(T,())),T) :- T = int, OP = (sub;pow).

--- a/src/constraint_handler/data/int.lp
+++ b/src/constraint_handler/data/int.lp
@@ -8,20 +8,12 @@ _computed(OP, ARGS, val(int, V1 + VTAIL)) :-
     ARGS = (val(int, V1), TAIL),
     _computed(OP, TAIL, val(int, VTAIL)).
 
-% _computed(OP, ARGS, val(int, 1)) :- _compute(OP, ARGS), OP=mult, ARGS = ().
-% _compute(OP, TAIL) :- _compute(OP, ARGS), OP=mult, ARGS = (val(int, _), TAIL).
-% _computed(OP, ARGS, val(int, V1 * VTAIL)) :-
-%     _compute(OP, ARGS),
-%     OP=mult,
-%     ARGS = (val(int, V1), TAIL),
-%     _computed(OP, TAIL, val(int, VTAIL)).
-
 % short circuit if there is a 0
 _computedIdx(E,val(int,0)) :- _computeIdx(E,mult), _computeIdx(E,IDX,val(int,0)).
 _computedIdx(E,val(int,1)) :- _computeIdx(E,mult), not _computeIdx(E, 0, _).
-_mult(E,0,val(int,1)) :- _computeIdx(E,mult).
-_mult(E,IDX+1,val(int,VO*V)) :- _computeIdx(E,mult), _computeIdx(E,IDX,val(int,V)), _mult(E,IDX,val(int,VO)).
-_computedIdx(E,V)  :- _computeIdx(E,mult), _mult(E,IDX,V),_computeIdx(E,IDX-1,_), not _computeIdx(E,IDX,_).
+_int_mult(E,0,val(int,1)) :- _computeIdx(E,mult).
+_int_mult(E,IDX+1,val(int,VO*V)) :- _computeIdx(E,mult), _computeIdx(E,IDX,val(int,V)), _int_mult(E,IDX,val(int,VO)).
+_computedIdx(E,V)  :- _computeIdx(E,mult), _int_mult(E,IDX,V),_computeIdx(E,IDX-1,_), not _computeIdx(E,IDX,_).
 
 %%%%%%%%%%%%%%%%% sub int_div pow
 operator_declare(OP,(T,(T,())),T) :- T = int, OP = (sub;pow).


### PR DESCRIPTION
>**Disclaimer**: This PR is not (yet?) supposed to be merged.

I have changed my previous implementation of `mult`, which uses the `compute` interface, such that it uses the `computeIdx` interface. This can probably be done cleaner, but I just wanted to provide a quick and dirty example.

The result are significant performance differences with the `compile` engine. Additionally, this allows short circuiting if there is a `0` in the arguments (can easily be extended to short circuit if there is no `0` but a `bad`).

However, as stated in #167 , this conflicts with the `fold` operator and potentially others that I may not know of.

I tested with several variations of an adapted example from #163 

```
variable_declare(d_v,  v(1..9),  fromFacts).
variable_domain(v(1..9),  val(int, 1..3)).
variable_define(d_r, result,
    operation(mult, (variable(v(1)),
        (variable(v(2)),
        (variable(v(3)),
        (variable(v(4)),
        (variable(v(5)),
        (variable(v(6)),
        (variable(v(7)),
        (variable(v(8)), 
        (variable(v(9)),
        ()))))))))))).
```