### PR TITLE
only remove navigation titles for larger displays

### DIFF
--- a/docs/_custom/css/extra.css
+++ b/docs/_custom/css/extra.css
@@ -40,8 +40,10 @@
     width: 1.5rem;
 }
 
-.md-nav--primary .md-nav__title {
-    display: none !important;
+@media (min-width: 1220px) {
+    .md-nav--primary .md-nav__title {
+        display: none !important;
+    }
 }
 
 /* Prevent wrapping in the first column of all tables */


### PR DESCRIPTION
This fixes an issue where the navigation of the documentation does not have a back button for smaller displays.