### PR TITLE
210 engine interaction compile   ground not working

### DIFF
--- a/src/constraint_handler/data/gringoEval.lp
+++ b/src/constraint_handler/data/gringoEval.lp
@@ -22,7 +22,7 @@ ge_expressionQuery(EXPR) :- _ge_assign(CNAME,X,EXPR).
 
 _ge_vQuery(X) :- ge_expressionQuery(EXPR), X=@pythonExpressionVariable(EXPR).
 
-_direct_implode(V) :- _ge_vQuery(X), _se_value(variable(X),V).
+_direct_implode(variable(X)) :- _ge_vQuery(X), _se_value(variable(X),_).
 ge_value(X,VAL) :- _ge_vQuery(X), _se_value(variable(X),val(T,V)), _direct_imploded(variable(X),VAL).
 
 

--- a/tests/example/engine_request_interaction.expected.all
+++ b/tests/example/engine_request_interaction.expected.all
@@ -1,0 +1,6 @@
+value(base_compile,val(int,1))
+value(base_ground,val(int,1))
+value(compile_to_ground,val(int,2))
+value(ground_to_compile,val(int,2))
+value(mixed_to_ground,val(int,2))
+value(mixed_to_compile,val(int,2))

--- a/tests/example/engine_request_interaction.lp
+++ b/tests/example/engine_request_interaction.lp
@@ -1,0 +1,18 @@
+variable_define(base_c, base_compile, val(int, 1)).
+variable_define(base_g, base_ground, val(int, 1)).
+
+requestEngine(base_c, compile).
+requestEngine(base_g, ground).
+
+
+variable_define(c_to_g, compile_to_ground, operation(add, (variable(base_compile), (variable(base_compile),())))).
+variable_define(g_to_c, ground_to_compile, operation(add, (variable(base_ground), (variable(base_ground),())))).
+
+requestEngine(c_to_g, ground).
+requestEngine(g_to_c, compile).
+
+variable_define(mixed_to_g, mixed_to_ground, operation(add, (variable(base_compile), (variable(base_ground),())))).
+variable_define(mixed_to_c, mixed_to_compile, operation(add, (variable(base_compile), (variable(base_ground),())))).
+
+requestEngine(mixed_to_g, ground).
+requestEngine(mixed_to_c, compile).

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -28,6 +28,7 @@ base_tests = [
     "custom_globals",
     "empty_variadics",
     "engine_request",
+    "engine_request_interaction",
     "engine_request_mult",
     "engine_request_set_ref",
     "eq_compound_int",


### PR DESCRIPTION
I've added a small test for engine interaction that failed on the old implementation.

Then I changed one line in gringoEval to pass all tests.

I don't yet understand the full underlying system, but my reasoning is as follows:

- I assumed that we need one `ge_value/2` for each variable that went through the ground engine at some point
- not all variables resulted in a `ge_value/2`
- there are only two ways to get `ge_value/2` in `gringoeval`
- one of them already contains the word `variable(X)` and uses `_direct_imploded/2`
- there's only one way to get `_direct_imploded/2` with `variable/1` as the first argument and that is through a `_direct_implode/1` that already contains the variable
- there is a rule in `gringoEval` that contains `_direct_implode/1` and also `variable(X)` but it passes the value and not the variable
- so I pass the variable instead

Again, I don't know if that is correct / intended, but it seems to fix the issue.