### PR TITLE
set extension: rename set_base_domain to set_baseDomain and reuse set…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Ongoing
 
+- Introduce set_baseDomain/2 to allow non-deterministic set definitions.
+
 ## v0.0.2.dev4
 
 - Use an aggregate to compute sum in the compule engine

--- a/docs/developer/fact-format.md
+++ b/docs/developer/fact-format.md
@@ -119,6 +119,7 @@ This page describes the EBNF grammar for the fact format used by the constraint 
 <set-atom> ::=
     | "set_declare" "(" <term> "," <term> ")"
     | "set_assign" "(" <term> "," <term> "," <expression> ")"
+    | "set_baseDomain" "(" <term> "," <term> "," <expression> ")"
 
 <execution-atom> ::=
     | "execution_declare" "(" <term> "," <term> "," <statement> "," <term-list> "," <term-list> ")"

--- a/docs/fact-format/fact-format.tex
+++ b/docs/fact-format/fact-format.tex
@@ -123,6 +123,7 @@
 <set-atom> ::=
 ~\alt `set_declare' `(' <term> `,' <term> `)'
 \alt `set_assign' `(' <term> `,' <term> `,' <expression> `)'
+\alt `set_baseDomain' `(' <term> `,' <term> `,' <expression> `)'
 
 <execution-atom> ::=
 ~\alt `execution_declare' `(' <term> `,' <term> `,' <statement> `,' <term-list> `,' <term-list> `)'

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -122,25 +122,6 @@ set_value(Name, Value)
 | `Name` | The unique identifier of the set. |
 | `Value` | The actual value being added to the set using the `val/2` predicate. |
 
-!!! Example
-    To create the set `my_set` and add the [ints] `1`, `3` and `5` to it, you would use the following code:
-
-    ```prolog
-    set_declare(my_set).
-    set_assign(my_set, val(int, 1)).
-    set_assign(my_set, val(int, 3)).
-    set_assign(my_set, val(int, 5)).
-    ```
-
-    This results in the following output atoms:
-
-    ```prolog
-    value(my_set, val(set, ref(variable(my_set))))
-    set_value(my_set, val(int, 1))
-    set_value(my_set, val(int, 3))
-    set_value(my_set, val(int, 5))
-    ```
-
 ### Base Domain
 
 To declare a set and specify a base domain of candidate values from which elements may be chosen, use the `set_baseDomain/2` predicate together with `set_declare/1`.
@@ -166,21 +147,19 @@ Each `set_baseDomain/2` fact introduces one candidate value. The solver may incl
 
     ```prolog
     set_declare(my_set).
-    set_baseDomain(my_set, val(int, 1..3)).
-    set_assign(my_set, val(int, 2)).
-    set_assign(my_set, val(int, 4)).
-    ensure(e1, operation(isin, (val(int, 1), (variable(my_set), ())))).
+    set_baseDomain(my_set,val(int,1..2)).
+    set_assign(my_set,val(int,3)).
+    ensure(e1,operation(isin,(val(int,1),(variable(my_set),())))).
     ```
 
-    This always produces (among other models):
+    This always produces (among other atoms):
 
     ```prolog
-    set_value(my_set, val(int, 1))
-    set_value(my_set, val(int, 2))
-    set_value(my_set, val(int, 4))
+    set_value(my_set,val(int,1))
+    set_value(my_set,val(int,3))
     ```
 
-    `val(int, 3)` may or may not appear, depending on the solver's choices.
+    The atom `set_value(my_set,val(int,2))` may or may not appear, depending on the solver's choices.
 
 ### Make
 

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -162,21 +162,25 @@ set_baseDomain(Name, Value).
 Each `set_baseDomain/2` fact introduces one candidate value. The solver may include or exclude each candidate independently.
 
 !!! Example
-    To create the set `my_set` with candidate values `1`, `2` and `3` (where the solver decides which ones to include), with a constraint that `1` must be included:
+    `set_assign` and `set_baseDomain` can be used together on the same set. Here, `my_set` has a base domain of candidates `1`, `2`, `3` (each optionally included by the solver), while `2` and `4` are always explicitly included via `set_assign`, and `1` is forced to appear via an `ensure` constraint:
 
     ```prolog
     set_declare(my_set).
     set_baseDomain(my_set, val(int, 1..3)).
+    set_assign(my_set, val(int, 2)).
+    set_assign(my_set, val(int, 4)).
     ensure(e1, operation(isin, (val(int, 1), (variable(my_set), ())))).
     ```
 
-    This results in (among other models):
+    This always produces (among other models):
 
     ```prolog
     set_value(my_set, val(int, 1))
+    set_value(my_set, val(int, 2))
+    set_value(my_set, val(int, 4))
     ```
 
-    The values `2` and `3` may or may not appear in the model, depending on the solver's choices, while `1` is guaranteed to appear due to the `ensure` constraint.
+    `val(int, 3)` may or may not appear, depending on the solver's choices.
 
 ### Make
 

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -141,6 +141,43 @@ set_value(Name, Value)
     set_value(my_set, val(int, 5))
     ```
 
+### Base Domain
+
+To declare a set and specify a base domain of candidate values from which elements may be chosen, use the `set_baseDomain/2` predicate together with `set_declare/1`.
+
+#### Input
+
+**[Declaration]**{.badge .declaration }
+
+```prolog
+set_declare(Name).
+set_baseDomain(Name, Value).
+```
+
+| Name | Description |
+| :--- | :--- |
+| `Name` | The unique identifier of the set. |
+| `Value` | A candidate value that may be included in the set. |
+
+Each `set_baseDomain/2` fact introduces one candidate value. The solver may include or exclude each candidate independently.
+
+!!! Example
+    To create the set `my_set` with candidate values `1`, `2` and `3` (where the solver decides which ones to include), with a constraint that `1` must be included:
+
+    ```prolog
+    set_declare(my_set).
+    set_baseDomain(my_set, val(int, 1..3)).
+    ensure(e1, operation(isin, (val(int, 1), (variable(my_set), ())))).
+    ```
+
+    This results in (among other models):
+
+    ```prolog
+    set_value(my_set, val(int, 1))
+    ```
+
+    The values `2` and `3` may or may not appear in the model, depending on the solver's choices, while `1` is guaranteed to appear due to the `ensure` constraint.
+
 ### Make
 
 The constraint handler provides a `set_make` operator to create sets directly within expressions.

--- a/src/constraint_handler/data/propagator.lp
+++ b/src/constraint_handler/data/propagator.lp
@@ -7,6 +7,7 @@ propagator_variable_domain(X,D) :- variable_domain(X,D), variable_declare(CNAME,
 propagator_variable_define(CNAME,X,E) :- variable_define(CNAME,X,E), engine(CNAME,propagator).
 
 propagator_set_assign(CNAME,X,E) :- set_assign(CNAME,X,E), engine(CNAME,propagator).
+propagator_set_baseDomain(CNAME,X,E) :- set_baseDomain(CNAME,X,E), engine(CNAME,propagator).
 propagator_set_declare(CNAME,X) :- set_declare(CNAME,X), engine(CNAME,propagator).
 
 propagator_multimap_assign(CNAME,X,K,V) :- multimap_assign(CNAME,X,K,V), engine(CNAME,propagator).

--- a/src/constraint_handler/data/set.lp
+++ b/src/constraint_handler/data/set.lp
@@ -1,14 +1,16 @@
 #defined set_declare/1.
 #defined set_assign/2.
 #defined set_declare_from/2.
-#defined set_base_domain/2.
+#defined set_baseDomain/2.
 
 
 set_declare(_label_anonymous,X) :- set_declare(X).
 set_assign(_label_anonymous,X,E) :- set_assign(X,E).
+set_baseDomain(_label_anonymous,X,V) :- set_baseDomain(X,V).
 
 engine(CNAME,ENG) :- _main_defaultEngine(ENG), not requestedEngine(CNAME), set_declare(CNAME,X).
 engine(CNAME,ENG) :- _main_defaultEngine(ENG), not requestedEngine(CNAME), set_assign(CNAME,X,EXPR).
+engine(CNAME,ENG) :- _main_defaultEngine(ENG), not requestedEngine(CNAME), set_baseDomain(CNAME,X,EXPR).
 _set_assign(CNAME,variable(X),E) :- engine(CNAME,compile), set_assign(CNAME,X,E).
 _set_declare(CNAME,variable(X)) :- engine(CNAME,compile), set_declare(CNAME,X).
 
@@ -36,23 +38,13 @@ _set_assign(NAME,EX,S) :- _set_assign(NAME,EX,ref(set,S)).
 
 set_value(X,V) :- _se_value(variable(X),ref(set,E)), _set_contains(E,V).
 
-%%%%%%%%%%%%%%%%% set_declare_from
-set_declare_from(_label_anonymous,X,From) :- set_declare_from(X,From).
-
-set_declare(CNAME,X) :- set_declare_from(CNAME,X,fromFacts).
-set_declare(CNAME,X) :- set_declare_from(CNAME,X,fromList(L)).
-_set_base_domain(X,V) :- set_declare_from(CNAME,X,fromFacts), set_base_domain(X,V).
-_set_base_domain(X,V) :- set_declare_from(CNAME,X,fromList(L)), V=@pythonListElements(L).
-
+%%%%%%%%%%%%%%%%% set_baseDomain
 { set_assign(CNAME,X,V) } :-
-    _set_base_domain(X,V), engine(CNAME, (compile;ground)), set_declare_from(CNAME,X,_).
+    set_baseDomain(CNAME,X,V), engine(CNAME,(compile;ground)).
 
 %%%% TODO - choosing the set assignment should be internal to the propagator
 { set_assign(CNAME,X,V) } :-
-    _set_base_domain(X,V), engine(CNAME, propagator), set_declare_from(CNAME,X,_).
-
-
-
+    set_baseDomain(CNAME,X,V), engine(CNAME,propagator).
 
 %%%%%%%%%%%%%%%%% isin notin
 operator_declare((isin;notin),(T1,(set,())),bool) :- _type(T1).

--- a/src/constraint_handler/data/set.lp
+++ b/src/constraint_handler/data/set.lp
@@ -1,6 +1,5 @@
 #defined set_declare/1.
 #defined set_assign/2.
-#defined set_declare_from/2.
 #defined set_baseDomain/2.
 
 
@@ -41,10 +40,6 @@ set_value(X,V) :- _se_value(variable(X),ref(set,E)), _set_contains(E,V).
 %%%%%%%%%%%%%%%%% set_baseDomain
 { set_assign(CNAME,X,V) } :-
     set_baseDomain(CNAME,X,V), engine(CNAME,(compile;ground)).
-
-%%%% TODO - choosing the set assignment should be internal to the propagator
-{ set_assign(CNAME,X,V) } :-
-    set_baseDomain(CNAME,X,V), engine(CNAME,propagator).
 
 %%%%%%%%%%%%%%%%% isin notin
 operator_declare((isin;notin),(T1,(set,())),bool) :- _type(T1).

--- a/src/constraint_handler/schemas/atom.py
+++ b/src/constraint_handler/schemas/atom.py
@@ -62,12 +62,18 @@ class Set_assign(NamedTuple):
     member: expression.Expr
 
 
+class Set_baseDomain(NamedTuple):
+    label: expression.constant
+    name: expression.constant
+    value: expression.Expr
+
+
 class Set_value(NamedTuple):
     name: expression.constant
     elt: expression.Val
 
 
-type SetAtom = Set_declare | Set_assign
+type SetAtom = Set_declare | Set_assign | Set_baseDomain
 
 
 class Multimap_declare(NamedTuple):
@@ -214,6 +220,10 @@ class Propagator_set_declare(Set_declare):
 
 
 class Propagator_set_assign(Set_assign):
+    pass
+
+
+class Propagator_set_baseDomain(Set_baseDomain):
     pass
 
 

--- a/tests/example/set_from_domain.expected.all
+++ b/tests/example/set_from_domain.expected.all
@@ -1,3 +1,3 @@
 set_value(s,val(int,1))
 set_value(s,val(int,2))
-set_value(t,val(symbol,red))
+set_value(s,val(int,4))

--- a/tests/example/set_from_domain.expected.any
+++ b/tests/example/set_from_domain.expected.any
@@ -1,3 +1,1 @@
 set_value(s,val(int,3))
-set_value(t,val(symbol,green))
-set_value(t,val(symbol,blue))

--- a/tests/example/set_from_domain.lp
+++ b/tests/example/set_from_domain.lp
@@ -1,17 +1,12 @@
-%%% Test set_declare_from/2 with fromList and fromFacts
+%%% Test set_declare/1 and set_baseDomain/2
 %%%
-%%% s has base domain {1, 2, 3} (via fromList)
-%%% Constrained: 1 and 2 must be in s
-%%% => s always contains 1 and 2; 3 is optional
-%%%
-%%% t has base domain {red, green, blue} (via fromFacts + set_base_domain)
-%%% Constrained: red must be in t
-%%% => t always contains red; green and blue are optional
+%%% s contains
+%%% * 1 because of set_baseDomain and ensure
+%%% * 2 because of set_assign
+%%% * maybe 3 because of set_baseDomain
+%%% * 4 because of set_assign
 
-set_declare_from(s, fromList((val(int,1),(val(int,2),(val(int,3),()))))).
+set_declare(s).
+set_baseDomain(s,val(int,1..3)).
 ensure(operation(isin,(val(int,1),(variable(s),())))).
-ensure(operation(isin,(val(int,2),(variable(s),())))).
-
-set_declare_from(t, fromFacts).
-set_base_domain(t, val(symbol,(red;green;blue))).
-ensure(operation(isin,(val(symbol,red),(variable(t),())))).
+set_assign(s,val(int,(2;4))).

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -146,6 +146,7 @@ def test_engine_propagator(name, check_mode):
         "optimize_ints",
         "optimize_priority",
         "set_fold_bools",
+        "set_from_domain",
         "set_iterations",
         "set_selfref",
         "warning_variables",


### PR DESCRIPTION
- [x] Add `Set_baseDomain` class to `src/constraint_handler/schemas/atom.py`
- [x] Update `SetAtom` type alias to include `Set_baseDomain`
- [x] Add `Propagator_set_baseDomain` propagator class to `atom.py`
- [x] Update `docs/reference/collections.md` to document `set_baseDomain/2` with a "Base Domain" section
- [x] Merge `set_assign` and `set_baseDomain` examples in `collections.md` into a single combined example
- [x] Update `docs/developer/fact-format.md` to add `set_baseDomain` to `<set-atom>` grammar
- [x] Update `docs/fact-format/fact-format.tex` to add `set_baseDomain` to `<set-atom>` grammar
- [x] All 222 tests pass