### PR TITLE
Fix bug that adds false_assignment as a variables value

### DIFF
--- a/src/constraint_handler/PropagatorVariables.py
+++ b/src/constraint_handler/PropagatorVariables.py
@@ -685,6 +685,7 @@ class Variable:
             return
         elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
             d[FALSE_ASSIGNMENTS].append(self.var)  # type: ignore
+            return
 
         d[self.var] = value
 
@@ -1004,6 +1005,7 @@ class SetVariable:
             return
         elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
             d[FALSE_ASSIGNMENTS].append(self.var)  # type: ignore
+            return
 
         d[self.var] = value
 
@@ -1249,6 +1251,7 @@ class DictVariable:
             return
         elif value == ValueStatus.ASSIGNMENT_IS_FALSE:
             d[FALSE_ASSIGNMENTS].append(self.var)  # type: ignore
+            return
 
         d[self.var] = value
 


### PR DESCRIPTION
- Fix bug where false assignments were sometimes added as a value to the evaluations dict in the propagator