### PR TITLE
Ks/propagator var domain fix

### DIFF
--- a/src/constraint_handler/propagator.py
+++ b/src/constraint_handler/propagator.py
@@ -850,6 +850,8 @@ class ConstraintHandlerPropagator(clingo.Propagator):
             ctl.add_watch(-literal)
 
             ctl.add_clause([-literal, domain_literal])
+            # literal defining the domain should also be included, not just the variable declaration literal!
+            ctl.add_clause([-literal, __literal])
 
             self.literal2var[literal] = [domain_variable]
 

--- a/tests/example/variable_flexible_domain.expected.any
+++ b/tests/example/variable_flexible_domain.expected.any
@@ -1,0 +1,2 @@
+value(baa,val(bool,true))
+value(baa,val(bool,false))

--- a/tests/example/variable_flexible_domain.expected.none
+++ b/tests/example/variable_flexible_domain.expected.none
@@ -1,0 +1,1 @@
+value(baa,val(none,none))

--- a/tests/example/variable_flexible_domain.lp
+++ b/tests/example/variable_flexible_domain.lp
@@ -1,0 +1,6 @@
+variable_declare(baa,fromFacts).
+variable_domain(baa,val(bool,true)).
+variable_domain(baa,val(bool,false)) :- sometimes.
+variable_domain(baa,val(none,none)) :- never.
+{ never } 0.
+{ sometimes }.

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -67,6 +67,7 @@ base_tests = [
     "sum_chain_performance",
     "type_checking",
     "variable_parallel_declaration",
+    "variable_flexible_domain",
     "variables",
     "warning_bad",
     "warning_fake_forbid",


### PR DESCRIPTION
- The truth value of variable_domain atoms is now taken into account when deciding the value of a variable when using the propagator (Fix #233)
- Add a test for this case 