### PR TITLE
add failed example for invalid warning

### DIFF
--- a/tests/correctness/warning/statement_python_declared_output.expected.all
+++ b/tests/correctness/warning/statement_python_declared_output.expected.all
@@ -1,0 +1,1 @@
+value(execution_output(test,"y"),val(int,3))

--- a/tests/correctness/warning/statement_python_declared_output.expected.none
+++ b/tests/correctness/warning/statement_python_declared_output.expected.none
@@ -1,0 +1,1 @@
+warning(variable(undeclared),(),((test,()),"y"))

--- a/tests/correctness/warning/statement_python_declared_output.lp
+++ b/tests/correctness/warning/statement_python_declared_output.lp
@@ -1,0 +1,12 @@
+execution_declare(test,
+    statement_python("y = x + 1"),
+    ("x",()),
+    ("y",())).
+
+variable_declare(execution_input(test,"x"),fromFacts).
+variable_domain(execution_input(test,"x"),val(int,2)).
+
+execution_run(test).
+
+#show value/2.
+#show warning/3.

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -80,6 +80,10 @@ base_tests = [
     "warning/fake_forbid",
     "warning/python",
     "warning/python_unsupported_type",
+    pytest.param(
+        "warning/statement_python_declared_output",
+        marks=pytest.mark.xfail(reason="known failing regression for statement_python declared outputs"),
+    ),
     "warning/statement_malformed",
     "warning/syntax",
     "warning/type",
@@ -146,11 +150,10 @@ def test_engine_ground(name: str):
 
 
 @pytest.mark.parametrize(
-    ["name", "check_mode"],
-    list(zip(base_tests + propagator_extra, [True] * len(base_tests + propagator_extra)))
-    + list(zip(base_tests + propagator_extra, [False] * len(base_tests + propagator_extra))),
+    "name",
+    base_tests + propagator_extra,
 )
-def test_engine_propagator(name, check_mode):
+def test_engine_propagator_check(name: str):
     unsupported: list[str] = [
         "core/type_checking",
         "datatype/bool_evaluate",
@@ -171,4 +174,32 @@ def test_engine_propagator(name, check_mode):
         "warning/variable_undeclared",
     ]
     if name not in unsupported:
-        run_test(name, "propagator", check_mode)
+        run_test(name, "propagator", True)
+
+
+@pytest.mark.parametrize(
+    "name",
+    base_tests + propagator_extra,
+)
+def test_engine_propagator(name: str):
+    unsupported: list[str] = [
+        "core/type_checking",
+        "datatype/bool_evaluate",
+        "engine/request",
+        "engine/request_mult",
+        "execution/python_integrity",
+        "expression/lambda_recursive",
+        "multimap/main",
+        "optimization/bools",
+        "optimization/floats",
+        "optimization/ints",
+        "optimization/priority",
+        "set/fold_bools",
+        "set/iterations",
+        "set/selfref",
+        "warning/python_unsupported_type",
+        "warning/variables",
+        "warning/variable_undeclared",
+    ]
+    if name not in unsupported:
+        run_test(name, "propagator", False)


### PR DESCRIPTION
Adds a failing example for an invalid warning when using the statement_python.
@AbdallahS feel free to write on my branch or delete it to work on this