### PR TITLE
Python caching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,10 @@
 
 ## v0.0.2.dev12
 
-- introduce caching for Python functions and dynamic Python executions and evaluations.
-- split `pythonIsTuple` and `pythonReify` in rule bodies to prevent `pythonReify` from being called for non-tuples.
+- introduce caching for Python functions and dynamic Python executions and
+  evaluations.
+- split `pythonIsTuple` and `pythonReify` in rule bodies to prevent
+  `pythonReify` from being called for non-tuples.
 - drop support for predicates `conditional_hasValue` and
   `conditional_hasNoValue`
 - fix typo in different-arity tuple equality and add a corresponding unit test

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Ongoing
 
+## v0.0.2.dev12
+
+- introduce caching for Python functions and dynamic Python executions and evaluations.
+- split `pythonIsTuple` and `pythonReify` in rule bodies to prevent `pythonReify` from being called for non-tuples.
 - drop support for predicates `conditional_hasValue` and
   `conditional_hasNoValue`
 - fix typo in different-arity tuple equality and add a corresponding unit test

--- a/scratch/performance.py
+++ b/scratch/performance.py
@@ -14,7 +14,7 @@ When False, the route decorator will perform no tracking or caching and will sim
 
 So this needs to be True in order for any of the performance tracking or caching features to be applied.
 """
-PERFORMANCE_TRACKING = False
+PERFORMANCE_TRACKING = True
 """
 When True, detailed performance data will be collected for each decorated function.
 
@@ -86,7 +86,7 @@ class Performance:
             "pythonStatementVariables": CacheMode.NATIVE,
             "pythonStringLength": CacheMode.NATIVE,
             "pythonTupleElements": CacheMode.NATIVE,
-            "pytocl": CacheMode.MANUAL,
+            "pytocl": CacheMode.NONE,
             "get_compiled_eval": CacheMode.NATIVE,
             "get_compiled_exec": CacheMode.NATIVE,
         }

--- a/src/constraint_handler/data/1_single_static_assignment/statement.lp
+++ b/src/constraint_handler/data/1_single_static_assignment/statement.lp
@@ -181,6 +181,9 @@ _variable(ssa,execution_input(PRG,X)) :- _execution_input_var(PRG,X).
 %%%%%%%%%%%%%%%%% sequence helpers
 _length(defaultArgs,operation(O,ARGS),N) :- _expression_sequenceHelper(defaultArgs,operation(O,ARGS)), N=@pythonListLength(ARGS).
 _expression_index(defaultArgs,operation(O,ARGS),IDX,X) :- _expression_sequenceHelper(defaultArgs,operation(O,ARGS)), (IDX,X)=@pythonEnumerateElements(ARGS).
-_expression_isTuple(defaultArgs,E,N,ARGS) :- _expression_sequenceHelper(defaultArgs,E), true=@pythonIsTuple(E), (function,(),N,ARGS)=@pythonReify(E).
+
+_expression_sequenceHelperisTuple(defaultArgs,E) :- _expression_sequenceHelper(defaultArgs,E), true=@pythonIsTuple(E).
+_expression_isTuple(defaultArgs,E,N,ARGS) :- _expression_sequenceHelperisTuple(defaultArgs,E), (function,(),N,ARGS)=@pythonReify(E).
+
 _length(defaultArgs,E,N) :- _expression_sequenceHelper(defaultArgs,E), _expression_isTuple(defaultArgs,E,N,ARGS).
 _expression_index(defaultArgs,E,IDX,X) :- _expression_sequenceHelper(defaultArgs,E), _expression_isTuple(defaultArgs,E,N,ARGS), (IDX,X)=@pythonEnumerateElements(ARGS).

--- a/src/constraint_handler/data/expression.lp
+++ b/src/constraint_handler/data/expression.lp
@@ -21,7 +21,9 @@ _variable(PHASE,X) :- _passed(PHASE,LBL,set_assign(X,E)).
 _variable(PHASE,X) :- _passed(PHASE,LBL,set_baseDomain(X,E)).
 _variable(PHASE,X) :- _passed(PHASE,LBL,multimap_assign(X,K,B)).
 
-_isTuple(PHASE,E,N,ARGS) :- _expression(PHASE,E), true=@pythonIsTuple(E), (function,(),N,ARGS)=@pythonReify(E).
+_isTuple(PHASE,E) :- _expression(PHASE,E), true=@pythonIsTuple(E).
+_isTuple(PHASE,E,N,ARGS) :- _isTuple(PHASE,E), (function,(),N,ARGS)=@pythonReify(E).
+
 _expression_tupleLength(PHASE,E,N) :- _isTuple(PHASE,E,N,ARGS).
 _expression_tupleIndex(PHASE,E,IDX,X) :- _isTuple(PHASE,E,N,ARGS), (IDX,X)=@pythonEnumerateElements(ARGS).
 _expression_operationOperator(PHASE,operation(OP,ARGS),OP) :- _expression(PHASE,operation(OP,ARGS)).

--- a/src/constraint_handler/data/pythonHelper.lp
+++ b/src/constraint_handler/data/pythonHelper.lp
@@ -1,13 +1,12 @@
 #script(python)
-
 import itertools
 import operator
 import typing
-
 from collections import defaultdict
 
 import clingo
 
+from constraint_handler.performance import performance
 import constraint_handler.myClorm as myClorm
 import constraint_handler.evaluator as evaluator
 import constraint_handler.schemas.atom as atom
@@ -19,25 +18,29 @@ import constraint_handler.solver_environment as solver_environment
 import constraint_handler.utils.python_statement_analysis as python_analysis
 
 
+@performance.route
 def pythonListElements(clL):
     try:
         return myClorm.cltopy(clL,list[clingo.Symbol])
     except myClorm.FailedInstantiationExn:
         return []
 
+@performance.route
 def pythonReversedList(clL):
     pL = pythonListElements(clL)
     return myClorm.pytocl(list(reversed(pL)))
 
+@performance.route
 def pythonEnumerateElements(clL):
     pL = pythonListElements(clL)
     return [myClorm.pytocl(e) for e in enumerate(pL)]
 
+@performance.route
 def pythonListLength(clL):
     pL = pythonListElements(clL)
     return myClorm.pytocl(len(pL))
 
-
+@performance.route
 def pythonIsList(clL):
     try:
         myClorm.cltopy(clL,list)
@@ -45,28 +48,32 @@ def pythonIsList(clL):
     except myClorm.FailedInstantiationExn:
         return myClorm.pytocl(False)
 
+@performance.route
 def pythonIsString(clS):
     return myClorm.pytocl(clS.type == clingo.SymbolType.String)
 
+@performance.route
 def pythonIsTuple(clT):
     return myClorm.pytocl(clT.type == clingo.SymbolType.Function and clT.name == "" and (len(clT.arguments) != 2 or clT.arguments[1] != clingo.Function("")))
 
+@performance.route
 def pythonTupleElements(clT):
     if clT.type == clingo.SymbolType.Function and clT.name == "":
         return clT.arguments
     else:
         return []
-
+@performance.route
 def pythonStringLength(clStr):
     pStr = myClorm.cltopy(clStr,str)
     return myClorm.pytocl(len(pStr))
 
+@performance.route
 def pythonStringAdd(clStr1,clStr2):
     pStr1 = myClorm.cltopy(clStr1,str)
     pStr2 = myClorm.cltopy(clStr2,str)
     return myClorm.pytocl(pStr1+pStr2)
 
-
+@performance.route
 def pythonScopeToString(clS,clVar):
     try:
         l = myClorm.cltopy(clS,list)
@@ -79,6 +86,7 @@ def pythonScopeToString(clS,clVar):
         return clS
         #return myClorm.pytocl(False)
 
+@performance.route
 def pythonReify(term):
     if term.type == clingo.SymbolType.Function:
         symb = clingo.symbol.Function(term.name)
@@ -89,6 +97,7 @@ def pythonReify(term):
     else:
         return myClorm.pytocl((clingo.symbol.Function("string"),term,0,()))
 
+@performance.route
 def pythonReflect(kind,term,args):
     if kind == clingo.symbol.Function("function") and term.type == clingo.SymbolType.Function:
         name = term.name

--- a/src/constraint_handler/data/pythonHelper.lp
+++ b/src/constraint_handler/data/pythonHelper.lp
@@ -3,10 +3,10 @@ import itertools
 import operator
 import typing
 from collections import defaultdict
+from functools import cache
 
 import clingo
 
-from constraint_handler.performance import performance
 import constraint_handler.myClorm as myClorm
 import constraint_handler.evaluator as evaluator
 import constraint_handler.schemas.atom as atom
@@ -18,29 +18,29 @@ import constraint_handler.solver_environment as solver_environment
 import constraint_handler.utils.python_statement_analysis as python_analysis
 
 
-@performance.route
+@cache
 def pythonListElements(clL):
     try:
         return myClorm.cltopy(clL,list[clingo.Symbol])
     except myClorm.FailedInstantiationExn:
         return []
 
-@performance.route
+@cache
 def pythonReversedList(clL):
     pL = pythonListElements(clL)
     return myClorm.pytocl(list(reversed(pL)))
 
-@performance.route
+@cache
 def pythonEnumerateElements(clL):
     pL = pythonListElements(clL)
     return [myClorm.pytocl(e) for e in enumerate(pL)]
 
-@performance.route
+@cache
 def pythonListLength(clL):
     pL = pythonListElements(clL)
     return myClorm.pytocl(len(pL))
 
-@performance.route
+@cache
 def pythonIsList(clL):
     try:
         myClorm.cltopy(clL,list)
@@ -48,32 +48,32 @@ def pythonIsList(clL):
     except myClorm.FailedInstantiationExn:
         return myClorm.pytocl(False)
 
-@performance.route
+@cache
 def pythonIsString(clS):
     return myClorm.pytocl(clS.type == clingo.SymbolType.String)
 
-@performance.route
+@cache
 def pythonIsTuple(clT):
     return myClorm.pytocl(clT.type == clingo.SymbolType.Function and clT.name == "" and (len(clT.arguments) != 2 or clT.arguments[1] != clingo.Function("")))
 
-@performance.route
+@cache
 def pythonTupleElements(clT):
     if clT.type == clingo.SymbolType.Function and clT.name == "":
         return clT.arguments
     else:
         return []
-@performance.route
+@cache
 def pythonStringLength(clStr):
     pStr = myClorm.cltopy(clStr,str)
     return myClorm.pytocl(len(pStr))
 
-@performance.route
+@cache
 def pythonStringAdd(clStr1,clStr2):
     pStr1 = myClorm.cltopy(clStr1,str)
     pStr2 = myClorm.cltopy(clStr2,str)
     return myClorm.pytocl(pStr1+pStr2)
 
-@performance.route
+@cache
 def pythonScopeToString(clS,clVar):
     try:
         l = myClorm.cltopy(clS,list)
@@ -86,7 +86,7 @@ def pythonScopeToString(clS,clVar):
         return clS
         #return myClorm.pytocl(False)
 
-@performance.route
+@cache
 def pythonReify(term):
     if term.type == clingo.SymbolType.Function:
         symb = clingo.symbol.Function(term.name)
@@ -97,7 +97,7 @@ def pythonReify(term):
     else:
         return myClorm.pytocl((clingo.symbol.Function("string"),term,0,()))
 
-@performance.route
+@cache
 def pythonReflect(kind,term,args):
     if kind == clingo.symbol.Function("function") and term.type == clingo.SymbolType.Function:
         name = term.name

--- a/src/constraint_handler/data/pythonInterface.lp
+++ b/src/constraint_handler/data/pythonInterface.lp
@@ -1,5 +1,7 @@
 #script (python)
+from constraint_handler.performance import performance
 
+@performance.route
 def pythonIsExpr(clE):
     try:
         myClorm.cltopy(clE,expression.Expr)
@@ -7,6 +9,7 @@ def pythonIsExpr(clE):
     except myClorm.FailedInstantiationExn:
         return myClorm.pytocl(False)
 
+@performance.route
 def pythonExpressionVariable(clExpr):
     try:
         pExpr = myClorm.cltopy(clExpr,expression.Expr)
@@ -16,7 +19,7 @@ def pythonExpressionVariable(clExpr):
     except:
         return []
 
-
+@performance.route
 def pythonEnumerateVariables(clExpr):
     try:
         pExpr = myClorm.cltopy(clExpr,expression.Expr)
@@ -27,6 +30,7 @@ def pythonEnumerateVariables(clExpr):
     except:
         return []
 
+@performance.route
 def pythonEnumerateExecutionVariables(clStmt,clIns):
     pStmt = myClorm.cltopy(clStmt,statement.Stmt)
     pIns = myClorm.cltopy(clIns,halt=False)
@@ -36,6 +40,7 @@ def pythonEnumerateExecutionVariables(clStmt,clIns):
     return result
 
  # TODO: dead?
+@performance.route
 def pythonBetaReduction(clExpr,clVars,clArgs):
     pVars = myClorm.cltopy(clVars,list)
     pArgs = myClorm.cltopy(clArgs,list[expression.ReducedExpr])
@@ -48,7 +53,7 @@ def pythonBetaReduction(clExpr,clVars,clArgs):
     pRes = evaluator.beta_reduction(d,pExpr)
     return myClorm.pytocl(pRes)
 
-
+@performance.route
 def pythonEvalExpr(clExpr,clArgs,clId):
     try:
         pArgs = myClorm.cltopy(clArgs,list[tuple[typing.Any,expression.ReducedExpr]])
@@ -67,7 +72,7 @@ def pythonEvalExpr(clExpr,clArgs,clId):
         for (kind,msg) in errors:
             results.append(warning.Error(kind,msg))
         results.append(evaluator.reducedExpr(pRes))
-        return map(myClorm.pytocl,results)
+        return [myClorm.pytocl(result) for result in results]
     except myClorm.FailedInstantiationExn as exn:
         kind = warning.Expression(warning.ExpressionWarning.pythonError)
         return myClorm.pytocl(warning.Error(kind,repr(exn)))
@@ -76,6 +81,7 @@ def pythonEvalExpr(clExpr,clArgs,clId):
         kind = warning.Expression(warning.ExpressionWarning.pythonError)
         return myClorm.pytocl(warning.Error(kind,repr(exn)))
 
+@performance.route
 def pythonStatementVariables(clCode,clInTypes,clId):
     try:
         pCode = myClorm.cltopy(clCode,str)
@@ -91,7 +97,7 @@ def pythonStatementVariables(clCode,clInTypes,clId):
         pyInputs = { x: frozenset((type_.py_type(t),)) for (x,t) in pInT }
         analysis = python_analysis.analyze_python_statement_types(pCode, globals, pyInputs)
         results = [(x,type_.ch_type(t)) for (x,ts) in analysis.name_types.items() for t in ts]
-        return map(myClorm.pytocl,results)
+        return [myClorm.pytocl(result) for result in results]
     except myClorm.FailedInstantiationExn as exn:
         kind = warning.Statement(warning.StatementWarning.syntaxError)
         return myClorm.pytocl(warning.Error(kind,str(exn)))

--- a/src/constraint_handler/data/pythonInterface.lp
+++ b/src/constraint_handler/data/pythonInterface.lp
@@ -1,7 +1,7 @@
 #script (python)
-from constraint_handler.performance import performance
+from functools import cache
 
-@performance.route
+@cache
 def pythonIsExpr(clE):
     try:
         myClorm.cltopy(clE,expression.Expr)
@@ -9,7 +9,7 @@ def pythonIsExpr(clE):
     except myClorm.FailedInstantiationExn:
         return myClorm.pytocl(False)
 
-@performance.route
+@cache
 def pythonExpressionVariable(clExpr):
     try:
         pExpr = myClorm.cltopy(clExpr,expression.Expr)
@@ -19,7 +19,7 @@ def pythonExpressionVariable(clExpr):
     except:
         return []
 
-@performance.route
+@cache
 def pythonEnumerateVariables(clExpr):
     try:
         pExpr = myClorm.cltopy(clExpr,expression.Expr)
@@ -30,7 +30,7 @@ def pythonEnumerateVariables(clExpr):
     except:
         return []
 
-@performance.route
+@cache
 def pythonEnumerateExecutionVariables(clStmt,clIns):
     pStmt = myClorm.cltopy(clStmt,statement.Stmt)
     pIns = myClorm.cltopy(clIns,halt=False)
@@ -40,7 +40,7 @@ def pythonEnumerateExecutionVariables(clStmt,clIns):
     return result
 
  # TODO: dead?
-@performance.route
+@cache
 def pythonBetaReduction(clExpr,clVars,clArgs):
     pVars = myClorm.cltopy(clVars,list)
     pArgs = myClorm.cltopy(clArgs,list[expression.ReducedExpr])
@@ -53,7 +53,7 @@ def pythonBetaReduction(clExpr,clVars,clArgs):
     pRes = evaluator.beta_reduction(d,pExpr)
     return myClorm.pytocl(pRes)
 
-@performance.route
+@cache
 def pythonEvalExpr(clExpr,clArgs,clId):
     try:
         pArgs = myClorm.cltopy(clArgs,list[tuple[typing.Any,expression.ReducedExpr]])
@@ -81,7 +81,7 @@ def pythonEvalExpr(clExpr,clArgs,clId):
         kind = warning.Expression(warning.ExpressionWarning.pythonError)
         return myClorm.pytocl(warning.Error(kind,repr(exn)))
 
-@performance.route
+@cache
 def pythonStatementVariables(clCode,clInTypes,clId):
     try:
         pCode = myClorm.cltopy(clCode,str)

--- a/src/constraint_handler/evaluator.py
+++ b/src/constraint_handler/evaluator.py
@@ -14,6 +14,7 @@ import constraint_handler.schemas.warning as warning
 import constraint_handler.set as myset
 import constraint_handler.solver_environment as solver_environment
 import constraint_handler.utils.python_statement_analysis as python_analysis
+from constraint_handler.performance import performance
 from constraint_handler.schemas.expression import (
     ConditionalOperator,
     EqOperator,
@@ -219,7 +220,7 @@ class Evaluator:
             return __succeeds
         else:
             try:
-                return eval(expr_code, nested.globals, nested.locals)
+                return eval(get_compiled_eval(expr_code), nested.globals, nested.locals)
             except Exception as exn:
                 kind = warning.Expression(warning.ExpressionWarning.pythonError)
                 self.errors.append((kind, repr(exn)))
@@ -311,7 +312,7 @@ class Evaluator:
                     return expression.Bad.bad
             case expression.Python(code):
                 try:
-                    result = eval(code, self.globals, self.locals)
+                    result = eval(get_compiled_eval(code), self.globals, self.locals)
                     return result
                 except Exception as exn:
                     kind = warning.Expression(warning.ExpressionWarning.pythonError)
@@ -347,7 +348,7 @@ class Evaluator:
 
     def stmt_python(self, code):
         try:
-            exec(code, self.globals, self.locals)
+            exec(get_compiled_exec(code), self.globals, self.locals)
         except solver_environment.FailIntegrityExn:
             raise
         except Exception as exn:
@@ -445,3 +446,13 @@ def get_environment(identifiers):
         else:
             print(f"undeclared globals for {identifier}")
     return globs
+
+
+@performance.route
+def get_compiled_eval(code: str):
+    return compile(code, "<string>", "eval")
+
+
+@performance.route
+def get_compiled_exec(code: str):
+    return compile(code, "<string>", "exec")

--- a/src/constraint_handler/evaluator.py
+++ b/src/constraint_handler/evaluator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from functools import cache
 
 import clingo
 
@@ -14,7 +15,6 @@ import constraint_handler.schemas.warning as warning
 import constraint_handler.set as myset
 import constraint_handler.solver_environment as solver_environment
 import constraint_handler.utils.python_statement_analysis as python_analysis
-from constraint_handler.performance import performance
 from constraint_handler.schemas.expression import (
     ConditionalOperator,
     EqOperator,
@@ -448,11 +448,11 @@ def get_environment(identifiers):
     return globs
 
 
-@performance.route
+@cache
 def get_compiled_eval(code: str):
     return compile(code, "<string>", "eval")
 
 
-@performance.route
+@cache
 def get_compiled_exec(code: str):
     return compile(code, "<string>", "exec")

--- a/src/constraint_handler/myClorm.py
+++ b/src/constraint_handler/myClorm.py
@@ -2,10 +2,9 @@ import enum
 import itertools
 import types
 import typing
+from functools import cache
 
 import clingo
-
-from constraint_handler.performance import performance
 
 
 class FailedInstantiationExn(Exception):
@@ -62,7 +61,6 @@ def _union_rows(target):
     return [target]
 
 
-@performance.route
 def pytocl(v, dtarget=None):
     if dtarget is None:
         dtarget = type(v)
@@ -150,7 +148,7 @@ def cltopyNoTarget(func):
         return func
 
 
-@performance.route
+@cache
 def cltopy(func, dtarget=typing.Any, halt=True):
     dtarget = _resolve_type_alias(dtarget)
     rows = _union_rows(dtarget)

--- a/src/constraint_handler/myClorm.py
+++ b/src/constraint_handler/myClorm.py
@@ -5,6 +5,8 @@ import typing
 
 import clingo
 
+from constraint_handler.performance import performance
+
 
 class FailedInstantiationExn(Exception):
     pass
@@ -60,6 +62,7 @@ def _union_rows(target):
     return [target]
 
 
+@performance.route
 def pytocl(v, dtarget=None):
     if dtarget is None:
         dtarget = type(v)
@@ -147,6 +150,7 @@ def cltopyNoTarget(func):
         return func
 
 
+@performance.route
 def cltopy(func, dtarget=typing.Any, halt=True):
     dtarget = _resolve_type_alias(dtarget)
     rows = _union_rows(dtarget)

--- a/src/constraint_handler/performance.py
+++ b/src/constraint_handler/performance.py
@@ -1,0 +1,236 @@
+"""
+Performance Tracking and Caching Module
+"""
+
+import time
+from collections import defaultdict
+from collections.abc import Iterator
+from enum import Enum, auto
+from functools import cache, wraps
+
+PERFORMANCE_ACTIVE = True
+"""
+When False, the route decorator will perform no tracking or caching and will simply return the original function.
+
+So this needs to be True in order for any of the performance tracking or caching features to be applied.
+"""
+PERFORMANCE_TRACKING = False
+"""
+When True, detailed performance data will be collected for each decorated function.
+
+
+This will have a significant overhead, so it should only be enabled during development and debugging!
+"""
+
+
+class CacheMode(Enum):
+    """Defines caching strategies for constraint handler functions."""
+
+    NONE = auto()
+    """No caching is applied."""
+
+    NATIVE = auto()
+    """Leverages Python's built-in functools.cache for fast caching of hashable inputs."""
+
+    MANUAL = auto()
+    """Implements a custom caching mechanism that can handle unhashable inputs by using a recursive key generation strategy."""
+
+
+class Performance:
+    """
+    Core Performance Tracking Class: Implements the logic for tracking function calls,
+    caching behavior, and timing, as well as collecting useful statistics for analysis.
+    """
+
+    def __init__(self, active=True, tracking=False):
+        """
+        Initializes the Performance tracking system.
+
+        Args:
+            active (bool): If False, the route decorator will perform no tracking or caching and
+              will simply return the original function.
+            tracking (bool): If True, detailed performance data will be collected for each decorated function.
+
+        """
+        self.active = active
+        self.tracking = tracking
+
+        self.stats = defaultdict(
+            lambda: {
+                "count": 0,
+                "cached": 0,
+                "repeated": 0,
+                "total_time": 0.0,
+                "func_time": 0.0,
+                "overhead_time": 0.0,
+                "seen_args": set(),
+                "cache": {},
+                "unhashable_args": False,
+            }
+        )
+
+        self.CONFIG = {
+            "cltopy": CacheMode.NATIVE,
+            "pythonEnumerateElements": CacheMode.NATIVE,
+            "pythonEvalExpr": CacheMode.NATIVE,
+            "pythonIsExpr": CacheMode.NATIVE,
+            "pythonIsList": CacheMode.NONE,
+            "pythonIsString": CacheMode.NATIVE,
+            "pythonIsTuple": CacheMode.NATIVE,
+            "pythonListElements": CacheMode.NATIVE,
+            "pythonListLength": CacheMode.NATIVE,
+            "pythonReflect": CacheMode.NONE,
+            "pythonReify": CacheMode.NATIVE,
+            "pythonScopeToString": CacheMode.NONE,
+            "pythonStatementVariables": CacheMode.NATIVE,
+            "pythonStringLength": CacheMode.NATIVE,
+            "pythonTupleElements": CacheMode.NATIVE,
+            "pytocl": CacheMode.MANUAL,
+        }
+
+    def route(self, func):
+        """
+        Unified decorator for routing constraint handler functions through the
+        performance tracking and caching system.
+
+        This method routes the given function through the appropriate caching and
+        tracking logic based on the configuration specified in self.CONFIG.
+
+        Args:
+            func (callable): The function to be decorated and routed through the performance system.
+        """
+        if not self.active:
+            return func
+
+        cache_mode = self.CONFIG.get(func.__name__, CacheMode.NONE)
+
+        match (cache_mode, self.tracking):
+            case (CacheMode.NATIVE, False):
+                return cache(func)
+            case (CacheMode.MANUAL, False):
+                return self._manual_cache_wrapper(func)
+            case (CacheMode.NATIVE, True) | (CacheMode.MANUAL, True):
+                return self._track_and_cache_wrapper(func, use_cache=True)
+            case (CacheMode.NONE, True):
+                return self._track_and_cache_wrapper(func, use_cache=False)
+            case _:
+                return func
+
+    def _make_key(self, obj):
+        """
+        Recursively generates a hashable key for potentially unhashable objects by encoding their type and contents.
+
+        This is used for caching and tracking purposes to identify function inputs.
+        """
+
+        obj_type = type(obj)
+        if isinstance(obj, (list, tuple, set, frozenset)):
+            return (obj_type, tuple(self._make_key(e) for e in obj))
+        elif isinstance(obj, dict):
+            return (obj_type, frozenset((self._make_key(k), self._make_key(v)) for k, v in obj.items()))
+        try:
+            hash(obj)
+        except TypeError:
+            if hasattr(obj, "__dict__"):
+                return (obj_type, self._make_key(vars(obj)))
+            return (obj_type, repr(obj))
+        return (obj_type, obj)
+
+    def _safe_deepcopy(self, obj):
+        """
+        Deep copies Python collections to prevent cache mutation.
+        Materializes one-shot iterators and safely ignores C-extensions like clingo.Symbol.
+        """
+
+        if isinstance(obj, (map, Iterator)):
+            return [self._safe_deepcopy(e) for e in obj]
+
+        obj_type = type(obj)
+        if obj_type is list:
+            return [self._safe_deepcopy(e) for e in obj]
+        elif obj_type is dict:
+            return {self._safe_deepcopy(k): self._safe_deepcopy(v) for k, v in obj.items()}
+        elif obj_type is set:
+            return {self._safe_deepcopy(e) for e in obj}
+        elif obj_type is tuple:
+            return tuple(self._safe_deepcopy(e) for e in obj)
+
+        return obj
+
+    def _manual_cache_wrapper(self, func):
+        """
+        Implements a manual caching mechanism for functions that may receive unhashable inputs.
+        """
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            stats = self.stats[func.__name__]
+            cache_dict = stats["cache"]
+            key = (self._make_key(args), self._make_key(kwargs))
+
+            if key in cache_dict:
+                stats["cached"] += 1
+                return self._safe_deepcopy(cache_dict[key])
+
+            snapshot = self._safe_deepcopy(func(*args, **kwargs))
+            cache_dict[key] = snapshot
+
+            return self._safe_deepcopy(snapshot)
+
+        return wrapper
+
+    def _track_and_cache_wrapper(self, func, use_cache):
+        """
+        Wraps the function to track performance metrics and optionally apply caching based on the specified mode.
+        """
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            t0 = time.perf_counter()
+
+            name = func.__name__
+            stats = self.stats[name]
+
+            if not stats["unhashable_args"]:
+                try:
+                    hash((args, frozenset(kwargs.items())))
+                except TypeError:
+                    stats["unhashable_args"] = True
+
+            arg_key = (self._make_key(args), self._make_key(kwargs))
+
+            if arg_key in stats["seen_args"]:
+                stats["repeated"] += 1
+            else:
+                stats["seen_args"].add(arg_key)
+
+            if use_cache and arg_key in stats["cache"]:
+                stats["cached"] += 1
+                result = self._safe_deepcopy(stats["cache"][arg_key])
+
+                t_end = time.perf_counter()
+                overhead_time = t_end - t0
+                func_time = 0.0
+            else:
+                t_pre_func = time.perf_counter()
+                result = func(*args, **kwargs)
+                t_post_func = time.perf_counter()
+
+                if use_cache:
+                    stats["cache"][arg_key] = self._safe_deepcopy(result)
+
+                t_end = time.perf_counter()
+                func_time = t_post_func - t_pre_func
+                overhead_time = (t_pre_func - t0) + (t_end - t_post_func)
+
+            stats["count"] += 1
+            stats["total_time"] += t_end - t0
+            stats["func_time"] += func_time
+            stats["overhead_time"] += overhead_time
+
+            return result
+
+        return wrapper
+
+
+performance = Performance(active=PERFORMANCE_ACTIVE, tracking=PERFORMANCE_TRACKING)

--- a/src/constraint_handler/performance.py
+++ b/src/constraint_handler/performance.py
@@ -60,6 +60,7 @@ class Performance:
                 "count": 0,
                 "cached": 0,
                 "repeated": 0,
+                "exceptions": 0,
                 "total_time": 0.0,
                 "func_time": 0.0,
                 "overhead_time": 0.0,
@@ -172,10 +173,13 @@ class Performance:
                 stats["cached"] += 1
                 return self._safe_deepcopy(cache_dict[key])
 
-            snapshot = self._safe_deepcopy(func(*args, **kwargs))
-            cache_dict[key] = snapshot
-
-            return self._safe_deepcopy(snapshot)
+            try:
+                snapshot = self._safe_deepcopy(func(*args, **kwargs))
+                cache_dict[key] = snapshot
+                return self._safe_deepcopy(snapshot)
+            except Exception:
+                stats["exceptions"] += 1
+                raise
 
         return wrapper
 
@@ -209,26 +213,32 @@ class Performance:
                 result = self._safe_deepcopy(stats["cache"][arg_key])
 
                 t_end = time.perf_counter()
-                overhead_time = t_end - t0
-                func_time = 0.0
-            else:
-                t_pre_func = time.perf_counter()
+
+                stats["count"] += 1
+                stats["overhead_time"] += t_end - t0
+                stats["total_time"] += t_end - t0
+                return result
+
+            t_pre_func = time.perf_counter()
+            try:
                 result = func(*args, **kwargs)
                 t_post_func = time.perf_counter()
 
                 if use_cache:
                     stats["cache"][arg_key] = self._safe_deepcopy(result)
 
+                return result
+            except Exception:
+                stats["exceptions"] += 1
+                t_post_func = time.perf_counter()
+                raise
+            finally:
                 t_end = time.perf_counter()
-                func_time = t_post_func - t_pre_func
-                overhead_time = (t_pre_func - t0) + (t_end - t_post_func)
 
-            stats["count"] += 1
-            stats["total_time"] += t_end - t0
-            stats["func_time"] += func_time
-            stats["overhead_time"] += overhead_time
-
-            return result
+                stats["count"] += 1
+                stats["func_time"] += t_post_func - t_pre_func
+                stats["overhead_time"] += (t_pre_func - t0) + (t_end - t_post_func)
+                stats["total_time"] += t_end - t0
 
         return wrapper
 

--- a/src/constraint_handler/performance.py
+++ b/src/constraint_handler/performance.py
@@ -87,6 +87,8 @@ class Performance:
             "pythonStringLength": CacheMode.NATIVE,
             "pythonTupleElements": CacheMode.NATIVE,
             "pytocl": CacheMode.MANUAL,
+            "get_compiled_eval": CacheMode.NATIVE,
+            "get_compiled_exec": CacheMode.NATIVE,
         }
 
     def route(self, func):


### PR DESCRIPTION
- introduce caching for Python functions and dynamic Python executions and evaluations.
- split `pythonIsTuple` and `pythonReify` in rule bodies to prevent `pythonReify` from being called for non-tuples.