### PR TITLE
add action to deploy docs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,53 @@
+name: Deploy Documentation
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    # tags:
+    #   - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.12
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[doc]
+      - name: Build the documentation
+        run: mkdocs build
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v6
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: "./site"
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}docs
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,10 @@
 site_name: constraint_handler
-site_url: https://potassco.org/systems/constraint_handler
+site_url: https://potassco.org/constraint-handler/docs
 site_description:
 repo_name: potassco/constraint_handler
-repo_url: https://github.com/potassco/constraint_handler
+repo_url: https://github.com/potassco/constraint-handler
 copyright: Copyright &copy; 2024 Potassco
+site_dir: site/docs
 
 extra_css:
   - _custom/css/extra.css


### PR DESCRIPTION
This PR adds an action that publishes the docs to potassco.org/constraint-handler/docs whenever there are pushes to main. The site is already live. Feel free to adjust this to only deploy on tags. I left the relevant code commented in the workflow.