### PR TITLE
Remove some grounding non-determinism

### DIFF
--- a/src/constraint_handler/myClorm.py
+++ b/src/constraint_handler/myClorm.py
@@ -150,7 +150,7 @@ def pytocl(v, dtarget=None):
     if dtarget is tuple:
         return clingo.Function("", [pytocl(e) for e in v])
     if dtarget is set or dtarget is frozenset:
-        return clingo.Function("set", [nest([pytocl(e) for e in v])])
+        return clingo.Function("set", [nest(sorted([pytocl(e) for e in v]))])
     if dtarget is clingo.Symbol:
         return v
 
@@ -185,7 +185,7 @@ def pytocl(v, dtarget=None):
         elif issubclass(runtime_target, list):
             return nest([pytocl(e) for e in v])
         elif issubclass(runtime_target, set) or issubclass(runtime_target, frozenset):
-            return clingo.Function("set", [nest([pytocl(e) for e in v])])
+            return clingo.Function("set", [nest(sorted([pytocl(e) for e in v]))])
         elif any(issubclass(runtime_target, cls) for cls in containers.values()):
             assert False
             n = next(name for name, cls in containers.items() if issubclass(runtime_target, cls))

--- a/src/constraint_handler/python_externals/interface.py
+++ b/src/constraint_handler/python_externals/interface.py
@@ -46,7 +46,8 @@ def pythonEnumerateVariables(clExpr):
     try:
         pExpr = myClorm.cltopy(clExpr, expression.Expr)
         pVars = list(evaluator.collectVars(pExpr))
-        result = sorted([myClorm.pytocl(e) for e in enumerate(pVars)])
+        subresult = sorted(myClorm.pytocl(v) for v in pVars)
+        result = [clingo.Function('',[clingo.Number(i), e]) for (i, e) in enumerate(subresult)]
         result.append(clingo.Function("length", [clingo.Number(len(pVars))]))
         return result
     except:
@@ -88,6 +89,7 @@ def pythonEvalExpr(clExpr, clArgs, clId):
         for kind, msg in errors:
             results.append(warning.Error(kind, msg))
         results.append(pVal)
+        return []
         return sorted([myClorm.pytocl(result) for result in results])
     except myClorm.FailedInstantiationExn as exn:
         kind = warning.Expression(warning.ExpressionWarning.pythonError)

--- a/src/constraint_handler/python_externals/interface.py
+++ b/src/constraint_handler/python_externals/interface.py
@@ -35,7 +35,7 @@ def pythonExpressionVariable(clExpr):
     try:
         pExpr = myClorm.cltopy(clExpr, expression.Expr)
         pVars = list(evaluator.collectVars(pExpr))
-        clVars = [myClorm.pytocl(var) for var in pVars]
+        clVars = sorted([myClorm.pytocl(var) for var in pVars])
         return clVars
     except:
         return []
@@ -46,7 +46,7 @@ def pythonEnumerateVariables(clExpr):
     try:
         pExpr = myClorm.cltopy(clExpr, expression.Expr)
         pVars = list(evaluator.collectVars(pExpr))
-        result = [myClorm.pytocl(e) for e in enumerate(pVars)]
+        result = sorted([myClorm.pytocl(e) for e in enumerate(pVars)])
         result.append(clingo.Function("length", [clingo.Number(len(pVars))]))
         return result
     except:
@@ -88,7 +88,7 @@ def pythonEvalExpr(clExpr, clArgs, clId):
         for kind, msg in errors:
             results.append(warning.Error(kind, msg))
         results.append(pVal)
-        return [myClorm.pytocl(result) for result in results]
+        return sorted([myClorm.pytocl(result) for result in results])
     except myClorm.FailedInstantiationExn as exn:
         kind = warning.Expression(warning.ExpressionWarning.pythonError)
         return myClorm.pytocl(warning.Error(kind, repr(exn)))
@@ -118,7 +118,7 @@ def pythonStatementVariables(clCode, clInTypes, clId):
                 for error in errs:
                     results.append(warning.Error(error, x))
                 results.append((x, cht))
-        return [myClorm.pytocl(result) for result in results]
+        return sorted([myClorm.pytocl(result) for result in results])
     except myClorm.FailedInstantiationExn as exn:
         kind = warning.Statement(warning.StatementWarning.syntaxError)
         return myClorm.pytocl(warning.Error(kind, str(exn)))

--- a/src/constraint_handler/python_externals/interface.py
+++ b/src/constraint_handler/python_externals/interface.py
@@ -89,7 +89,6 @@ def pythonEvalExpr(clExpr, clArgs, clId):
         for kind, msg in errors:
             results.append(warning.Error(kind, msg))
         results.append(pVal)
-        return []
         return sorted([myClorm.pytocl(result) for result in results])
     except myClorm.FailedInstantiationExn as exn:
         kind = warning.Expression(warning.ExpressionWarning.pythonError)

--- a/src/constraint_handler/python_externals/interface.py
+++ b/src/constraint_handler/python_externals/interface.py
@@ -89,7 +89,7 @@ def pythonEvalExpr(clExpr, clArgs, clId):
         for kind, msg in errors:
             results.append(warning.Error(kind, msg))
         results.append(pVal)
-        return sorted([myClorm.pytocl(result) for result in results])
+        return [myClorm.pytocl(result) for result in results]
     except myClorm.FailedInstantiationExn as exn:
         kind = warning.Expression(warning.ExpressionWarning.pythonError)
         return myClorm.pytocl(warning.Error(kind, repr(exn)))

--- a/src/constraint_handler/python_externals/interface.py
+++ b/src/constraint_handler/python_externals/interface.py
@@ -47,7 +47,7 @@ def pythonEnumerateVariables(clExpr):
         pExpr = myClorm.cltopy(clExpr, expression.Expr)
         pVars = list(evaluator.collectVars(pExpr))
         subresult = sorted(myClorm.pytocl(v) for v in pVars)
-        result = [clingo.Function('',[clingo.Number(i), e]) for (i, e) in enumerate(subresult)]
+        result = [clingo.Function("", [clingo.Number(i), e]) for (i, e) in enumerate(subresult)]
         result.append(clingo.Function("length", [clingo.Number(len(pVars))]))
         return result
     except:

--- a/tests/test_myclorm.py
+++ b/tests/test_myclorm.py
@@ -97,6 +97,13 @@ def test_cltopy_without_target_decodes_primitives_and_collections():
     assert myClorm.cltopyNoTarget(myClorm.pytocl(frozenset({1, 2}))) == frozenset({1, 2})
 
 
+def test_cltopy_set_is_encoded_with_clingo_ordered_elements():
+    elements = [2, 1, "b", "a"]  # note: Python doesn't support`sorting of mixed types but clingo does.
+    symbol = myClorm.pytocl(frozenset(elements))
+    clingo_elements = sorted([clingo.Number(1), clingo.Number(2), clingo.String("a"), clingo.String("b")])
+    assert symbol == clingo.Function("set", [myClorm.pytocl(clingo_elements)])
+
+
 def test_cltopy_typed_namedtuple_decodes_symbol():
     symbol = clingo.Function("sampleRecord", [clingo.Number(4), clingo.String("item")])
 

--- a/tests/test_python_externals_interface.py
+++ b/tests/test_python_externals_interface.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import clingo
+
+import constraint_handler.myClorm as myClorm
+import constraint_handler.python_externals.interface as interface
+import constraint_handler.schemas.expression as expression
+import constraint_handler.schemas.warning as warning
+
+
+def _clear_interface_caches() -> None:
+    interface.pythonExpressionVariable.cache_clear()
+    interface.pythonEnumerateVariables.cache_clear()
+    interface.pythonEvalExpr.cache_clear()
+    interface.pythonStatementVariables.cache_clear()
+
+
+def test_python_expression_variable_returns_sorted_symbols():
+    _clear_interface_caches()
+
+    expr = (expression.Variable("b"), expression.Variable("a"))
+    cl_expr = myClorm.pytocl(expr)
+
+    result = interface.pythonExpressionVariable(cl_expr)
+
+    assert result == [clingo.String("a"), clingo.String("b")]
+
+
+def test_python_enumerate_variables_sorts_enumerated_symbols():
+    _clear_interface_caches()
+
+    expr = (expression.Variable("b"), expression.Variable("a"))
+    cl_expr = myClorm.pytocl(expr)
+
+    result = interface.pythonEnumerateVariables(cl_expr)
+
+    expected_a_then_b = [
+        myClorm.pytocl((0, "a")),
+        myClorm.pytocl((1, "b")),
+        clingo.Function("length", [clingo.Number(2)]),
+    ]
+    assert result == expected_a_then_b
+
+
+def test_python_statement_variables_returns_sorted_symbols():
+    _clear_interface_caches()
+
+    cl_code = myClorm.pytocl("b = 1.0\na = 1")
+    cl_in_types = myClorm.pytocl([])
+    cl_id = myClorm.pytocl([])
+
+    result = interface.pythonStatementVariables(cl_code, cl_in_types, cl_id)
+
+    expected = sorted(
+        [
+            myClorm.pytocl(("a", interface.type_.BaseType.int)),
+            myClorm.pytocl(("b", interface.type_.BaseType.float)),
+        ]
+    )
+    assert result == expected

--- a/tests/test_python_externals_interface.py
+++ b/tests/test_python_externals_interface.py
@@ -5,7 +5,6 @@ import clingo
 import constraint_handler.myClorm as myClorm
 import constraint_handler.python_externals.interface as interface
 import constraint_handler.schemas.expression as expression
-import constraint_handler.schemas.warning as warning
 
 
 def _clear_interface_caches() -> None:


### PR DESCRIPTION
Python's hash function is randomly seeded on each instantiation of the interpreter. So iterating over elements of a dictionary can produce a different ordering between different runs of the same program. 

To make the grounding of CH programs more deterministic some of these iterations are wrapped with `sorted()` calls so the output is sorted (based on `clingo.Symbol` order).

@AbdallahS I'm sure I haven't caught all such instances, but at least the proposed changes seem to work for the problem instances that I have been using.  Note: `myClorm` line 203 is one more case that probably should be wrapped with a call to `sorted()`, but I didn't modify it because I didn't fully understand what sort of output it should be producing.