### PR TITLE
fix version regex for revisions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
           if [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
             echo "version=${TAG_NAME#v}" >> "$GITHUB_OUTPUT"
             echo "repository_url=https://pypi.org/legacy/" >> "$GITHUB_OUTPUT"
-          elif [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[1-9][0-9]$ ]]; then
+          elif [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[1-9][0-9]*$ ]]; then
             echo "version=${TAG_NAME#v}" >> "$GITHUB_OUTPUT"
             echo "repository_url=https://test.pypi.org/legacy/" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
Fix deployment regex. The variant before enforced two-digit revision numbers due to the missing `*`.